### PR TITLE
Add cross-platform VS Code config

### DIFF
--- a/AppData/Roaming/Code/User/keybindings.json.tmpl
+++ b/AppData/Roaming/Code/User/keybindings.json.tmpl
@@ -1,0 +1,1 @@
+{{- template "vscode-keybindings.json.tmpl" . -}}

--- a/AppData/Roaming/Code/User/settings.json.tmpl
+++ b/AppData/Roaming/Code/User/settings.json.tmpl
@@ -1,0 +1,1 @@
+{{- template "vscode-settings.json.tmpl" . -}}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Dotfiles
+
+This repository contains configuration files for multiple platforms.
+
+The VS Code settings and keybindings are defined in `.chezmoitemplates`. Copies of
+these templates are placed under each platform's default settings directory so
+chezmoi installs them correctly on macOS, Linux and Windows:
+
+- `Library/Application Support/Code/User/` (macOS)
+- `dot_config/Code/User/` (Linux)
+- `AppData/Roaming/Code/User/` (Windows)
+
+Running `chezmoi apply` will copy the template to the appropriate location on
+whichever OS you're using.

--- a/dot_config/Code/User/keybindings.json.tmpl
+++ b/dot_config/Code/User/keybindings.json.tmpl
@@ -1,0 +1,1 @@
+{{- template "vscode-keybindings.json.tmpl" . -}}

--- a/dot_config/Code/User/settings.json.tmpl
+++ b/dot_config/Code/User/settings.json.tmpl
@@ -1,0 +1,1 @@
+{{- template "vscode-settings.json.tmpl" . -}}


### PR DESCRIPTION
## Summary
- add VS Code settings/keybindings paths for Linux and Windows
- document cross-platform setup in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869224a3ab8832db822c1d6b0e5986b