### PR TITLE
Remove contributor instructions

### DIFF
--- a/run_once_30-cross-platform-setup.sh.tmpl
+++ b/run_once_30-cross-platform-setup.sh.tmpl
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Set up cross-platform tools for Windows, macOS and Linux
+set -e
+
+OS="$(uname -s)"
+
+# Common packages installed on macOS, Windows and Linux
+COMMON_APPS=(
+    git
+    ripgrep
+    fd
+    fzf
+    bat
+    delta
+    less
+    llvm
+    nvim
+)
+FONT_APP=firacode-nerd-font
+
+case "$OS" in
+    Darwin)
+        echo "Running macOS setup..."
+        if command -v brew >/dev/null 2>&1; then
+            for pkg in "${COMMON_APPS[@]}"; do
+                brew install "$pkg" || true
+            done
+            brew tap homebrew/cask-fonts >/dev/null 2>&1 || true
+            brew install --cask "$FONT_APP" || true
+            brew install --cask alt-tab || true
+        else
+            echo "Homebrew not installed. Skipping package installs."
+        fi
+        if command -v defaults >/dev/null 2>&1; then
+            defaults write -g ApplePressAndHoldEnabled -bool false
+        else
+            echo "defaults command not available."
+        fi
+        ;;
+    MINGW*|MSYS*|CYGWIN*)
+        echo "Running Windows setup using Scoop..."
+        if command -v pwsh >/dev/null 2>&1; then
+            pwsh -NoProfile -Command "iwr -useb get.scoop.sh | iex" || true
+            pwsh -NoProfile -Command "scoop bucket add extras" || true
+            pwsh -NoProfile -Command "scoop bucket add nerd-fonts" || true
+            for pkg in ${COMMON_APPS[*]}; do
+                pwsh -NoProfile -Command "scoop install $pkg" || true
+            done
+            pwsh -NoProfile -Command "scoop install $FONT_APP" || true
+        elif command -v powershell >/dev/null 2>&1; then
+            powershell -NoProfile -Command "iwr -useb get.scoop.sh | iex" || true
+            powershell -NoProfile -Command "scoop bucket add extras" || true
+            powershell -NoProfile -Command "scoop bucket add nerd-fonts" || true
+            for pkg in ${COMMON_APPS[*]}; do
+                powershell -NoProfile -Command "scoop install $pkg" || true
+            done
+            powershell -NoProfile -Command "scoop install $FONT_APP" || true
+        else
+            echo "PowerShell is required to run Scoop but was not found."
+        fi
+        ;;
+    Linux)
+        echo "Running Linux setup using apt..."
+        if command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update -y -qq || true
+            for pkg in "${COMMON_APPS[@]}"; do
+                apt_pkg="$pkg"
+                [ "$pkg" = "fd" ] && apt_pkg="fd-find"
+                [ "$pkg" = "nvim" ] && apt_pkg="neovim"
+                sudo apt-get install -y "$apt_pkg" || true
+            done
+            sudo apt-get install -y fonts-firacode || true
+        else
+            echo "apt-get not found. Skipping package installs."
+        fi
+        ;;
+    *)
+        echo "No setup steps for OS $OS";;
+esac


### PR DESCRIPTION
## Summary
- delete AGENTS guidelines
- keep macOS setup including alt-tab install and ApplePressAndHold defaults command

## Testing
- `bash ./run_once_30-cross-platform-setup.sh.tmpl`
- `/tmp/chezmoi-bin/chezmoi --source=. apply --dry-run -v`


------
https://chatgpt.com/codex/tasks/task_e_6869702e1584832db4ad5e9d686995d6