### PR TITLE
Enable macOS clipboard shortcuts in Neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,12 @@ The setting is defined in `dot_config/chezmoi/chezmoi.toml`:
 ```toml
 mode = "symlink"
 ```
+
+## Neovim
+
+On macOS, common Command shortcuts work in Neovim:
+
+- **⌘C** copies the current selection to the system clipboard.
+- **⌘X** cuts the selection.
+- **⌘V** pastes the clipboard in Normal, Visual and Insert modes.
+- **⌘A** selects the entire buffer.

--- a/dot_config/nvim/lua/config/keymaps.lua
+++ b/dot_config/nvim/lua/config/keymaps.lua
@@ -84,6 +84,14 @@ map("n", "<A-o>", "<cmd>ClangdSwitchSourceHeader<CR>", { desc = "Switch header/s
 map("n", "<D-Left>", "<C-o>", { desc = "Jump backward" })
 map("n", "<D-Right>", "<C-i>", { desc = "Jump forward" })
 
+-- macOS clipboard shortcuts
+map("v", "<D-c>", '"+y', { desc = "Copy selection" })
+map("v", "<D-x>", '"+d', { desc = "Cut selection" })
+map("n", "<D-v>", '"+p', { desc = "Paste" })
+map("v", "<D-v>", '"+p', { desc = "Paste over selection" })
+map("i", "<D-v>", "<C-r>+", { desc = "Paste" })
+map("n", "<D-a>", "ggVG", { desc = "Select all" })
+
 vim.keymap.del("n", "<S-h>")
 vim.keymap.del("n", "<S-l>")
 


### PR DESCRIPTION
## Summary
- add mappings for Cmd-C/V/X/A on macOS
- document the new shortcuts in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686998baede4832d8c9f8912bbb987ce