### PR TITLE
Make Homebrew install scripts non-interactive

### DIFF
--- a/darwin/run_once_30-setup.sh.tmpl
+++ b/darwin/run_once_30-setup.sh.tmpl
@@ -10,7 +10,7 @@ echo "Running macOS setup using Homebrew..."
 # Check if Homebrew is installed
 if ! command -v brew >/dev/null 2>&1; then
     echo "Installing Homebrew..."
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     
     # Add Homebrew to PATH for Apple Silicon Macs
     if [[ $(uname -m) == "arm64" ]]; then

--- a/linux/run_once_30-setup.sh.tmpl
+++ b/linux/run_once_30-setup.sh.tmpl
@@ -22,7 +22,7 @@ $SUDO apt-get install -y build-essential libc6-dev pkg-config || true
 # Install Homebrew if not present
 if ! command -v brew >/dev/null 2>&1; then
     echo "Installing Homebrew..."
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" || true
+    NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" || true
     
     # Add Homebrew to PATH
     if [ -f "/home/linuxbrew/.linuxbrew/bin/brew" ]; then


### PR DESCRIPTION
## Summary
- run the Homebrew install script with `NONINTERACTIVE=1`

## Testing
- `bash -n darwin/run_once_30-setup.sh.tmpl`
- `bash -n linux/run_once_30-setup.sh.tmpl`


------
https://chatgpt.com/codex/tasks/task_e_6869fd44b178832d947ea0cae7596ab3