### PR TITLE
Implement key print toggle

### DIFF
--- a/dot_config/nvim/lua/config/keymaps.lua
+++ b/dot_config/nvim/lua/config/keymaps.lua
@@ -1,4 +1,5 @@
 local map = vim.keymap.set
+local print_keys = require("config.print_keys")
 
 -- Use screen-line motions for arrow keys in Normal, Visual & Operator-Pending modes
 for _, mode in ipairs({ "n", "v", "o" }) do
@@ -19,12 +20,7 @@ for _, mode in ipairs({ "n", "i", "v", "o", "t" }) do
   map(mode, "<ScrollWheelRight>", "<Nop>", { silent = true, desc = "Disable → scroll" })
 end
 
--- TODO: Move this debug print of current key into another file & make it so that it's disabled by default but on a bool
--- Log every key pressed in nvim (any mode)
--- vim.on_key(function(char)
---   -- You can use vim.fn.mode() to check the current mode if you want to filter
---   vim.notify("Key pressed: " .. vim.inspect(char))
--- -- end, vim.api.nvim_create_namespace("log-keys"))
+
 
 --------------------------------------------------------------------------
 -- Shift+Function key helpers -------------------------------------------
@@ -54,6 +50,11 @@ map_shift_f(7, "<cmd>CMakeStop<CR>", { desc = "Stop Build" })
 
 -- Go to LSP definition
 map_shift_f(8, vim.lsp.buf.definition, { desc = "Goto Definition" })
+
+-- Leader-based toggle for key print debugging
+vim.keymap.set("n", "<leader>uk", print_keys.toggle, {
+  desc = "Toggle Key Print",
+})
 
 -- Toggle comment on the current line  ── normal mode
 vim.keymap.set("n", "<S-F11>", "gcc", { remap = true, silent = true, desc = "Toggle Comment (line)" })

--- a/dot_config/nvim/lua/config/print_keys.lua
+++ b/dot_config/nvim/lua/config/print_keys.lua
@@ -1,0 +1,41 @@
+local M = {}
+
+local ns = vim.api.nvim_create_namespace("print-keys")
+local enabled = false
+local print_file = vim.fn.stdpath("state") .. "/key-press.log"
+
+local function handler(char)
+  local f = io.open(print_file, "a")
+  if f then
+    f:write(string.format("%s [%s] %s\n", os.date("%F %T"), vim.fn.mode(), vim.inspect(char)))
+    f:close()
+  end
+end
+
+function M.enable()
+  if enabled then
+    return
+  end
+  vim.on_key(handler, ns)
+  enabled = true
+  vim.notify("Key print enabled", vim.log.levels.INFO)
+end
+
+function M.disable()
+  if not enabled then
+    return
+  end
+  vim.on_key(nil, ns)
+  enabled = false
+  vim.notify("Key print disabled", vim.log.levels.INFO)
+end
+
+function M.toggle()
+  if enabled then
+    M.disable()
+  else
+    M.enable()
+  end
+end
+
+return M


### PR DESCRIPTION
## Summary
- add `print_keys.lua` module for debugging typed keys
- map `<leader>uk` to toggle the key print feature
- update notifications to say "key print" when toggled

## Testing
- `chezmoi apply --dry-run -S .` *(fails: command not found)*
- `chezmoi doctor -S .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b049563dc832da6540386b9d81637