### PR TITLE
Add terminal shortcut in nvim

### DIFF
--- a/dot_config/nvim/lua/config/keymaps.lua
+++ b/dot_config/nvim/lua/config/keymaps.lua
@@ -56,6 +56,9 @@ vim.keymap.set("n", "<leader>uk", print_keys.toggle, {
   desc = "Toggle Key Print",
 })
 
+-- Open a terminal
+vim.keymap.set("n", "<leader>r", "<cmd>terminal<CR>", { desc = "Open terminal" })
+
 -- Toggle comment on the current line  ── normal mode
 vim.keymap.set("n", "<S-F11>", "gcc", { remap = true, silent = true, desc = "Toggle Comment (line)" })
 


### PR DESCRIPTION
## Summary
- add `<leader>r` mapping in nvim to open a terminal

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_686b236f1084832dab0525ff61f2f61d