### PR TITLE
Add shift-arrow buffer switching

### DIFF
--- a/dot_config/nvim/lua/config/keymaps.lua
+++ b/dot_config/nvim/lua/config/keymaps.lua
@@ -104,3 +104,7 @@ vim.keymap.del("n", "<S-l>")
 -- map("n", "<D-S-]>", ":bnext<CR>", { desc = "Next buffer" })
 -- Previous buffer: Cmd+Shift+[
 -- map("n", "<D-S-[>", ":bprevious<CR>", { desc = "Previous buffer" })
+
+-- Navigate buffers with Shift+Arrow keys
+map("n", "<S-Left>", ":bprevious<CR>", { desc = "Previous buffer" })
+map("n", "<S-Right>", ":bnext<CR>", { desc = "Next buffer" })

--- a/dot_vsvimrc
+++ b/dot_vsvimrc
@@ -124,6 +124,9 @@ nnoremap <leader>ep :vsc View.PreviousError<CR>
 " Tabs
 nnoremap ]b :vsc Window.NextTab<CR>
 nnoremap [b :vsc Window.PreviousTab<CR>
+" Switch tabs with Shift+Left/Right arrows
+nnoremap <S-Left> :vsc Window.PreviousTab<CR>
+nnoremap <S-Right> :vsc Window.NextTab<CR>
 nnoremap <leader>bd :vsc Window.CloseDocumentWindow<CR>
 nnoremap <leader>bp :vsc Window.PinTab<CR>
 nnoremap <leader>bP :vsc Window.CloseAllButPinned<CR>


### PR DESCRIPTION
## Summary
- enable shifting between buffers with shift-left/right in Neovim
- mirror the same behaviour in the Visual Studio `.vsvimrc`

## Testing
- `chezmoi apply --dry-run -S .`
- `/tmp/bin/chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_686b2fe11468832d97e712ab8608e3c4