### PR TITLE
Fix buffer navigation mappings

### DIFF
--- a/dot_config/nvim/lua/config/keymaps.lua
+++ b/dot_config/nvim/lua/config/keymaps.lua
@@ -106,5 +106,5 @@ vim.keymap.del("n", "<S-l>")
 -- map("n", "<D-S-[>", ":bprevious<CR>", { desc = "Previous buffer" })
 
 -- Navigate buffers with Shift+Arrow keys
-map("n", "<S-Left>", ":bprevious<CR>", { desc = "Previous buffer" })
-map("n", "<S-Right>", ":bnext<CR>", { desc = "Next buffer" })
+map("n", "<S-Left>", "<cmd>bprevious<CR>", { desc = "Previous buffer", silent = true })
+map("n", "<S-Right>", "<cmd>bnext<CR>", { desc = "Next buffer", silent = true })


### PR DESCRIPTION
## Summary
- keep buffer navigation keys from flashing `:` prompt by using `<cmd>` and `silent`

## Testing
- `stylua --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b3665b208832d9afe1ec434939c9a