### PR TITLE
Update Docker example to use Debian testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ chezmoi init --apply skyde
 Try it yourself in a Docker container.
 
 ```sh
-docker run --rm -it debian bash -c 'apt update && apt install -y curl git && curl -fsSL get.chezmoi.io | bash -s -- init --apply skyde && exec bash'
+docker run --rm -it debian:testing bash -c 'apt update && apt install -y curl git && curl -fsSL get.chezmoi.io | bash -s -- init --apply skyde && exec bash'
 
 ```
 


### PR DESCRIPTION
## Summary
- update `README.md` docker run example to pull from `debian:testing`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686c6e4350e0832d93a3a1bca242671a