### PR TITLE
Install zsh and load config on Linux

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -27,7 +27,11 @@ bindkey '^[[1;5D' backward-word    # Ctrl+Left
 eval "$(starship init zsh)"
 
 # Inline suggestions
-source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+if [ -f /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]; then
+  source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+elif [ -f /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]; then
+  source /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+fi
 
 # Autocomplete
 autoload -Uz compinit && compinit
@@ -35,7 +39,11 @@ zstyle ':completion:*' menu select
 zstyle ':completion:*' matcher-list 'm:{a-z}={A-Za-z}'
 
 # Syntax highlighting
-source /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+if [ -f /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh ]; then
+  source /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+elif [ -f /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh ]; then
+  source /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+fi
 
 eval "$(zoxide init zsh)"
 

--- a/linux/run_once_30-setup.sh.tmpl
+++ b/linux/run_once_30-setup.sh.tmpl
@@ -32,11 +32,24 @@ for pkg in "${COMMON_APPS[@]}"; do
     APT_PACKAGES+=("$apt_pkg")
 done
 
+# Install zsh and helpful plugins
+APT_PACKAGES+=(zsh zsh-autosuggestions zsh-syntax-highlighting)
+
 echo "Installing: ${APT_PACKAGES[*]}"
 $SUDO apt-get install -y "${APT_PACKAGES[@]}" || true
 
 # Install Fira Code font using apt
 $SUDO apt-get install -y fonts-firacode || true
+
+# Set zsh as the default shell if available
+if command -v zsh >/dev/null 2>&1; then
+    ZSH_PATH=$(command -v zsh)
+    CURRENT_SHELL=$(getent passwd "$USER" | cut -d: -f7)
+    if [ "$CURRENT_SHELL" != "$ZSH_PATH" ]; then
+        echo "Changing default shell to $ZSH_PATH"
+        $SUDO chsh -s "$ZSH_PATH" "$USER" || true
+    fi
+fi
 
 # Final debug check
 echo "=== FINAL DEBUG ==="


### PR DESCRIPTION
## Summary
- install zsh along with plugins during Linux setup
- automatically set zsh as the default shell
- source plugin paths on Linux or macOS

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_686c80490ac8832da392f75d7baa8ff6