### PR TITLE
Add cross-platform auto update helper

### DIFF
--- a/Documents/PowerShell/Microsoft.PowerShell_profile.ps1
+++ b/Documents/PowerShell/Microsoft.PowerShell_profile.ps1
@@ -11,6 +11,10 @@ Set-PSReadLineOption -HistorySavePath "$HOME\.powershell_history"
 Set-PSReadLineKeyHandler -Key Ctrl+RightArrow  -Function ForwardWord
 Set-PSReadLineKeyHandler -Key Ctrl+LeftArrow   -Function BackwardWord
 
+# Auto-update dotfiles on startup using helper script
+$updateScript = "$HOME/bin/chezmoi-auto-update.ps1"
+if (Test-Path $updateScript) { & $updateScript }
+
 # Starship prompt (only if installed)
 if (Get-Command starship -ErrorAction SilentlyContinue) {
     Invoke-Expression (& starship init powershell)

--- a/bin/chezmoi-auto-update
+++ b/bin/chezmoi-auto-update
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if command -v chezmoi >/dev/null 2>&1; then
+  chezmoi update --init >/dev/null 2>&1
+fi

--- a/bin/chezmoi-auto-update.ps1
+++ b/bin/chezmoi-auto-update.ps1
@@ -1,0 +1,4 @@
+#!/usr/bin/env pwsh
+if (Get-Command chezmoi -ErrorAction SilentlyContinue) {
+    chezmoi update --init | Out-Null
+}

--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -3,6 +3,7 @@
 
 # Inserts a blank line between shell prompts
 add_newline = true
+command_timeout = 1000
 
 # Replace the '❯' symbol in the prompt with '➜'
 [character] # The name of the module we are configuring is 'character'

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -5,6 +5,11 @@ fi
 # Path setup (add custom bins before system paths)
 export PATH="$HOME/bin:/usr/local/bin:$PATH"
 
+# Auto-update dotfiles on login using helper script
+if command -v chezmoi-auto-update >/dev/null 2>&1; then
+  chezmoi-auto-update
+fi
+
 # Shell Options
 setopt autocd             # Enter directory just by typing its name
 setopt correct            # Auto correct command typos


### PR DESCRIPTION
## Summary
- add helper scripts `chezmoi-auto-update` and `chezmoi-auto-update.ps1`
- run helper from zsh and PowerShell profiles before the prompt is initialised
- tune starship `command_timeout` to reduce startup warnings

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_686c72188948832db3314ada02f4678f