### PR TITLE
Add fullscreen shortcut for VSCode

### DIFF
--- a/.chezmoitemplates/vscode-settings.json.tmpl
+++ b/.chezmoitemplates/vscode-settings.json.tmpl
@@ -93,7 +93,8 @@
         { "before": ["]", "b"], "commands": ["workbench.action.nextEditor"] },
         { "before": ["[", "b"], "commands": ["workbench.action.previousEditor"] },
         { "before": ["<leader>", "b", "d"], "commands": ["workbench.action.closeActiveEditor"] },
-        { "before": ["<leader>", "b", "o"], "commands": ["workbench.action.closeOtherEditors"] }
+        { "before": ["<leader>", "b", "o"], "commands": ["workbench.action.closeOtherEditors"] },
+        { "before": ["<leader>", "w", "f"], "commands": ["workbench.action.toggleFullScreen"] }
     ],
     // "vim.visualModeKeyBindingsNonRecursive": [
     //     { "before": ["<C-s>"], "commands": ["editor.action.formatDocument", "workbench.action.files.save"] }


### PR DESCRIPTION
## Summary
- add `<leader>wf` mapping in `vscode-settings.json.tmpl` to toggle full screen

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_686cac68d8c4832daa0da4c9416db34f