### PR TITLE
Configure tab keys for vscode vim indentation

### DIFF
--- a/.chezmoitemplates/vscode-settings.json.tmpl
+++ b/.chezmoitemplates/vscode-settings.json.tmpl
@@ -34,6 +34,10 @@
     // Use system clipboard in Vim extension
     "vim.useSystemClipboard": true,
     "vim.useCtrlKeys": true,
+    "vim.handleKeys": {
+        "<tab>": false,
+        "<S-tab>": false
+    },
 
     // Search behaviour like Vim
     "vim.ignorecase": true,


### PR DESCRIPTION
## Summary
- disable VSCodeVim handling for `<tab>` and `<S-tab>`

## Testing
- `chezmoi apply --dry-run -S . --verbose`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_686d08d4339c832da00e42eba39b57a2