### PR TITLE
Improve VS Code defaults

### DIFF
--- a/.chezmoitemplates/vscode-settings.json.tmpl
+++ b/.chezmoitemplates/vscode-settings.json.tmpl
@@ -13,6 +13,12 @@
 
     // Increase terminal scrollback similar to using a terminal split in Neovim
     "terminal.integrated.scrollback": 10000,
+    "editor.fontFamily": "FiraCode Nerd Font, Fira Code, monospace",
+    "editor.fontLigatures": true,
+    "terminal.integrated.fontFamily": "FiraCode Nerd Font, Fira Code, monospace",
+    "terminal.integrated.defaultProfile.linux": "zsh",
+    "terminal.integrated.defaultProfile.osx": "zsh",
+    "terminal.integrated.defaultProfile.windows": "pwsh",
 
     // Cursor Shape & Style
     "editor.cursorStyle": "line",           // options: "line", "block", "underline", "line-thin", "block-outline", "underline-thin"


### PR DESCRIPTION
## Summary
- use FiraCode Nerd Font in VS Code
- set default terminal profiles for each OS

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_686d163e5e78832daf60d57bfba59a46