### PR TITLE
Improve README and auto-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 ### Mac
 
 ```sh
-sudo apt update
-sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply skyde
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+brew install chezmoi
+chezmoi init --apply skyde
 ```
 
 ### Linux

--- a/bin/chezmoi-auto-update
+++ b/bin/chezmoi-auto-update
@@ -1,5 +1,9 @@
 #!/bin/sh
 
 if command -v chezmoi >/dev/null 2>&1; then
-  chezmoi update --init >/dev/null 2>&1
+  if [ -z "$(chezmoi git status --porcelain)" ]; then
+    chezmoi update --init >/dev/null 2>&1
+  else
+    [ -n "$DEBUG" ] && echo "chezmoi has local changes, skipping auto update."
+  fi
 fi


### PR DESCRIPTION
## Summary
- fix instructions for macOS in the README
- skip chezmoi auto-update when repo has local changes

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`
- `shellcheck bin/chezmoi-auto-update`


------
https://chatgpt.com/codex/tasks/task_e_686da9001c8c832d8bad584f0871d9ad