### PR TITLE
Add shell tests for auto update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,11 @@ jobs:
 
       - name: Doctor
         run: chezmoi doctor -S .
+
+      - name: Install bats (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y bats
+
+      - name: Run shell tests
+        if: runner.os == 'Linux'
+        run: bats -r tests

--- a/tests/chezmoi-auto-update.bats
+++ b/tests/chezmoi-auto-update.bats
@@ -1,0 +1,40 @@
+setup() {
+  TMPDIR=$(mktemp -d)
+  STUB=$TMPDIR/chezmoi
+  cat > "$STUB" <<'SH'
+#!/bin/sh
+if [ "$1" = "git" ] && [ "$2" = "status" ] && [ "$3" = "--porcelain" ]; then
+  printf "%s" "$GIT_STATUS_OUTPUT"
+elif [ "$1" = "update" ] && [ "$2" = "--init" ]; then
+  echo update >> "$CALLED_FILE"
+fi
+SH
+  chmod +x "$STUB"
+  export PATH="$TMPDIR:$PATH"
+  export CALLED_FILE="$TMPDIR/called"
+}
+
+teardown() {
+  rm -rf "$TMPDIR"
+}
+
+@test "does nothing when chezmoi missing" {
+  PATH="/nonexistent" run "$BATS_TEST_DIRNAME/../bin/chezmoi-auto-update"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "runs update when repo is clean" {
+  GIT_STATUS_OUTPUT=""
+  run "$BATS_TEST_DIRNAME/../bin/chezmoi-auto-update"
+  [ "$status" -eq 0 ]
+  [ -f "$CALLED_FILE" ]
+}
+
+@test "skips update when repo has changes" {
+  GIT_STATUS_OUTPUT=" M file"
+  DEBUG=1 run "$BATS_TEST_DIRNAME/../bin/chezmoi-auto-update"
+  [ "$status" -eq 0 ]
+  [ ! -f "$CALLED_FILE" ]
+  [ "$output" = "chezmoi has local changes, skipping auto update." ]
+}


### PR DESCRIPTION
## Summary
- add Bats tests for `chezmoi-auto-update`
- run tests in GitHub Actions on Linux

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`
- `bats -r tests`

------
https://chatgpt.com/codex/tasks/task_e_686dabe0a2b0832da420d146a59f7494