### PR TITLE
Update VS Code bindings

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json.tmpl
+++ b/.chezmoitemplates/vscode-keybindings.json.tmpl
@@ -45,5 +45,74 @@
         "key": "pageup",
         "command": "scrollPageUp",
         "when": "textInputFocus"
+    },
+    // Terminal navigation
+    {
+        "key": "ctrl+shift+a",
+        "command": "workbench.action.terminal.focusNext",
+        "when": "terminalFocus"
+    },
+    {
+        "key": "ctrl+shift+b",
+        "command": "workbench.action.terminal.focusPrevious",
+        "when": "terminalFocus"
+    },
+    {
+        "key": "ctrl+shift+j",
+        "command": "workbench.action.togglePanel"
+    },
+    {
+        "key": "ctrl+shift+n",
+        "command": "workbench.action.terminal.new",
+        "when": "terminalFocus"
+    },
+    {
+        "key": "ctrl+shift+w",
+        "command": "workbench.action.terminal.kill",
+        "when": "terminalFocus"
+    },
+    // File explorer
+    {
+        "command": "workbench.action.toggleSidebarVisibility",
+        "key": "ctrl+e"
+    },
+    {
+        "command": "workbench.files.action.focusFilesExplorer",
+        "key": "ctrl+e",
+        "when": "editorTextFocus"
+    },
+    {
+        "key": "n",
+        "command": "explorer.newFile",
+        "when": "filesExplorerFocus && !inputFocus"
+    },
+    {
+        "command": "renameFile",
+        "key": "r",
+        "when": "filesExplorerFocus && !inputFocus"
+    },
+    {
+        "key": "shift+n",
+        "command": "explorer.newFolder",
+        "when": "explorerViewletFocus"
+    },
+    {
+        "key": "shift+n",
+        "command": "workbench.action.newWindow",
+        "when": "!explorerViewletFocus"
+    },
+    {
+        "command": "deleteFile",
+        "key": "d",
+        "when": "filesExplorerFocus && !inputFocus"
+    },
+    // Extra
+    {
+        "key": "ctrl+shift+5",
+        "command": "editor.emmet.action.matchTag"
+    },
+    {
+        "key": "ctrl+z",
+        "command": "workbench.action.toggleZenMode"
     }
 ]

--- a/.chezmoitemplates/vscode-settings.json.tmpl
+++ b/.chezmoitemplates/vscode-settings.json.tmpl
@@ -19,6 +19,18 @@
     "terminal.integrated.defaultProfile.linux": "zsh",
     "terminal.integrated.defaultProfile.osx": "zsh",
     "terminal.integrated.defaultProfile.windows": "pwsh",
+    "editor.formatOnSave": true,
+    "editor.suggest.insertMode": "replace",
+    "editor.linkedEditing": true,
+    "javascript.updateImportsOnFileMove.enabled": "always",
+    "window.zoomLevel": 0.5,
+    "workbench.statusBar.visible": false,
+    "breadcrumbs.enabled": false,
+    "workbench.iconTheme": "material-icon-theme",
+    "update.showReleaseNotes": false,
+    "workbench.activityBar.visible": false,
+    "zenMode.hideLineNumbers": false,
+    "zenMode.hideTabs": false,
 
     // Cursor Shape & Style
     "editor.cursorStyle": "line",           // options: "line", "block", "underline", "line-thin", "block-outline", "underline-thin"
@@ -104,11 +116,31 @@
         { "before": ["[", "b"], "commands": ["workbench.action.previousEditor"] },
         { "before": ["<leader>", "b", "d"], "commands": ["workbench.action.closeActiveEditor"] },
         { "before": ["<leader>", "b", "o"], "commands": ["workbench.action.closeOtherEditors"] },
-        { "before": ["<leader>", "w", "f"], "commands": ["workbench.action.toggleFullScreen"] }
+        { "before": ["<leader>", "w", "f"], "commands": ["workbench.action.toggleFullScreen"] },
+        { "before": ["<S-h>"], "commands": [":bprevious"] },
+        { "before": ["<S-l>"], "commands": [":bnext"] },
+        { "before": ["leader", "v"], "commands": [":vsplit"] },
+        { "before": ["leader", "s"], "commands": [":split"] },
+        { "before": ["leader", "h"], "commands": ["workbench.action.focusLeftGroup"] },
+        { "before": ["leader", "j"], "commands": ["workbench.action.focusBelowGroup"] },
+        { "before": ["leader", "k"], "commands": ["workbench.action.focusAboveGroup"] },
+        { "before": ["leader", "l"], "commands": ["workbench.action.focusRightGroup"] },
+        { "before": ["leader", "w"], "commands": [":w!"] },
+        { "before": ["leader", "q"], "commands": [":q!"] },
+        { "before": ["leader", "x"], "commands": [":x!"] },
+        { "before": ["[", "d"], "commands": ["editor.action.marker.prev"] },
+        { "before": ["]", "d"], "commands": ["editor.action.marker.next"] },
+        { "before": ["<leader>", "c", "a"], "commands": ["editor.action.quickFix"] },
+        { "before": ["<leader>", "p"], "commands": ["editor.action.formatDocument"] },
+        { "before": ["g", "h"], "commands": ["editor.action.showDefinitionPreviewHover"] }
     ],
-    // "vim.visualModeKeyBindingsNonRecursive": [
-    //     { "before": ["<C-s>"], "commands": ["editor.action.formatDocument", "workbench.action.files.save"] }
-    // ],
+    "vim.visualModeKeyBindings": [
+        { "before": ["<"], "commands": ["editor.action.outdentLines"] },
+        { "before": [">"], "commands": ["editor.action.indentLines"] },
+        { "before": ["J"], "commands": ["editor.action.moveLinesDownAction"] },
+        { "before": ["K"], "commands": ["editor.action.moveLinesUpAction"] },
+        { "before": ["leader", "c"], "commands": ["editor.action.commentLine"] }
+    ],
     // "vim.insertModeKeyBindingsNonRecursive": [
     //     { "before": ["<C-s>"], "commands": ["editor.action.formatDocument", "workbench.action.files.save"] },
     // ],


### PR DESCRIPTION
## Summary
- add extra VS Code shortcuts inspired by Melkeydev/vscode_bindings
- extend Vim keybindings and general settings

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_686daf00ae68832db0b67d9ae2a0cd21