### PR TITLE
Fix clipboard sync in vsvimrc

### DIFF
--- a/dot_vsvimrc
+++ b/dot_vsvimrc
@@ -18,7 +18,8 @@ set hlsearch
 set nostartofline
 
 " Clipboard and backspace support
-set clipboard=unnamed
+" Sync both * and + registers with the system clipboard
+set clipboard=unnamed,unnamedplus
 set backspace=indent,eol,start
 
 " Reload vimrc


### PR DESCRIPTION
## Summary
- sync `*` and `+` registers with system clipboard

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_686db14903c4832d8cabd15ef492979d