### PR TITLE
Configure macOS key repeat settings

### DIFF
--- a/darwin/run_once_30-setup.sh.tmpl
+++ b/darwin/run_once_30-setup.sh.tmpl
@@ -48,3 +48,12 @@ echo "Installing fonts..."
 brew install --cask font-fira-code-nerd-font || echo "Failed to install font-fira-code-nerd-font, continuing..."
 
 echo "macOS setup complete!"
+
+# Configure key repeat behavior for Vim and general usage
+echo "Setting macOS key repeat defaults..."
+defaults write -g ApplePressAndHoldEnabled -bool false
+# Shorter delay before key repeat starts (default is 68)
+defaults write -g InitialKeyRepeat -int 15
+# Faster repeat rate (default is 6)
+defaults write -g KeyRepeat -int 2
+echo "Key repeat settings applied. You may need to log out and back in for changes to take effect."


### PR DESCRIPTION
## Summary
- adjust macOS setup script to set `ApplePressAndHoldEnabled`, `InitialKeyRepeat` and `KeyRepeat`

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_686db8a6b9b8832da9effd608d2ebec9