### PR TITLE
Add vig mapping to vsvimrc

### DIFF
--- a/dot_vsvimrc
+++ b/dot_vsvimrc
@@ -38,6 +38,9 @@ nnoremap <Down> j
 nnoremap <Up> k
 nnoremap <Right> l
 
+" Select the entire buffer
+nnoremap vig ggVG
+
 " Half page scroll is fixed size
 nnoremap <C-u> 16k
 nnoremap <C-d> 16j


### PR DESCRIPTION
## Summary
- allow `vig` to select the entire buffer in Visual Studio Vim

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_686ecf9188b0832db2bd1949d8ef7ce2