### PR TITLE
Update VS Code vim to clear search highlight

### DIFF
--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -259,6 +259,11 @@
     {
       "before": ["g", "h"],
       "commands": ["editor.action.showDefinitionPreviewHover"]
+    },
+    {
+      "before": ["<Esc>"],
+      "after": ["<Esc>"],
+      "commands": [":nohl"]
     }
   ],
   "vim.visualModeKeyBindings": [


### PR DESCRIPTION
## Summary
- map `<Esc>` in VS Code Vim to run `:nohl` so search highlighting disappears

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_686ed388a36c832da3c77f87657fe2d3