### PR TITLE
Set black backgrounds

### DIFF
--- a/dot_config/kitty/kitty.conf
+++ b/dot_config/kitty/kitty.conf
@@ -1,0 +1,1 @@
+background #000000

--- a/dot_config/nvim/lua/config/options.lua
+++ b/dot_config/nvim/lua/config/options.lua
@@ -34,3 +34,13 @@ if vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1 or vim.fn.has("win32unix
 end
 
 vim.opt.clipboard:append("unnamedplus")
+
+-- Force a black background
+vim.opt.background = "dark"
+vim.api.nvim_create_autocmd("ColorScheme", {
+  pattern = "*",
+  callback = function()
+    vim.api.nvim_set_hl(0, "Normal", { bg = "#000000" })
+  end,
+})
+vim.api.nvim_set_hl(0, "Normal", { bg = "#000000" })

--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -20,3 +20,9 @@ set -g default-terminal "tmux-256color"
 
 # Don't eat events that the program should receive (though there is still some issue here)
 unbind -n C-s
+
+# Black background for status and panes
+set -g status-bg black
+set -g pane-border-style "bg=black"
+set -g pane-active-border-style "bg=black"
+set -g message-style "bg=black"


### PR DESCRIPTION
## Summary
- set a kitty config with a black background
- force a black background in neovim
- change tmux status and pane styles to use black

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_686f42392670832d81d9e2b6c1542070