### PR TITLE
Configure kitty with FiraCode Nerd Font

### DIFF
--- a/dot_config/kitty/kitty.conf
+++ b/dot_config/kitty/kitty.conf
@@ -1,1 +1,8 @@
 background #000000
+
+# Use FiraCode Nerd Font with ligatures enabled
+font_family FiraCode Nerd Font
+bold_font FiraCode Nerd Font Bold
+italic_font FiraCode Nerd Font Italic
+bold_italic_font FiraCode Nerd Font Bold Italic
+disable_ligatures never


### PR DESCRIPTION
## Summary
- configure kitty font to use FiraCode Nerd Font and ligatures

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_686fa6dea45c832d87a093fa04779699