### PR TITLE
Fix terminal opacity

### DIFF
--- a/dot_config/kitty/kitty.conf
+++ b/dot_config/kitty/kitty.conf
@@ -12,7 +12,6 @@ disable_ligatures never
 # Quality of life improvements
 scrollback_lines 10000         # Keep a longer history
 enable_audio_bell no           # Disable terminal bell
-background_opacity 0.95        # Slight transparency
 confirm_os_window_close 0      # Don't prompt when closing
 macos_option_as_alt yes        # Map Option to Alt on macOS
 


### PR DESCRIPTION
## Summary
- remove explicit opacity setting from `kitty.conf` to keep background fully opaque

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_686fbb5d928c832daa315c74eabe8fc8