### PR TITLE
Fix inline comments in kitty config

### DIFF
--- a/dot_config/kitty/kitty.conf
+++ b/dot_config/kitty/kitty.conf
@@ -10,10 +10,10 @@ bold_italic_font FiraCode Nerd Font Bold Italic
 disable_ligatures never
 
 # Quality of life improvements
-scrollback_lines 10000         # Keep a longer history
-enable_audio_bell no           # Disable terminal bell
-confirm_os_window_close 0      # Don't prompt when closing
-macos_option_as_alt yes        # Map Option to Alt on macOS
+scrollback_lines 10000
+enable_audio_bell no
+confirm_os_window_close 0
+macos_option_as_alt yes
 
 # Clipboard shortcuts
 map ctrl+shift+c copy_to_clipboard


### PR DESCRIPTION
## Summary
- remove inline comments from kitty.conf

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_686fbee4597c832da59492d6bf716e67