### PR TITLE
Add bp/bP mappings for VSCode Vim

### DIFF
--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -292,6 +292,14 @@
       "commands": ["editor.action.showDefinitionPreviewHover"]
     },
     {
+      "before": ["b", "p"],
+      "commands": ["workbench.action.pinEditor"]
+    },
+    {
+      "before": ["b", "P"],
+      "commands": ["workbench.action.closeOtherEditors"]
+    },
+    {
       "before": ["<Esc>"],
       "after": ["<Esc>"],
       "commands": [":nohl"]


### PR DESCRIPTION
## Summary
- add `bp` mapping to pin the current editor
- add `bP` mapping to close other editors

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_686fd06775a0832db2462bee9eefc3e7