### PR TITLE
Add yank whole document shortcuts

### DIFF
--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -159,6 +159,10 @@
       "after": ["g", "g", "V", "G"]
     },
     {
+      "before": ["y", "i", "g"],
+      "after": ["g", "g", "V", "G", "y"]
+    },
+    {
       "before": ["g", "d"],
       "commands": ["editor.action.revealDefinition"]
     },

--- a/dot_vsvimrc
+++ b/dot_vsvimrc
@@ -40,6 +40,8 @@ nnoremap <Right> l
 
 " Select the entire buffer
 nnoremap vig ggVG
+" Copy the entire buffer to the clipboard
+nnoremap yig ggVGy
 
 " Half page scroll is fixed size
 nnoremap <C-u> 16k


### PR DESCRIPTION
## Summary
- map `yig` in VsVim to yank the entire buffer
- map `yig` in VS Code Vim to yank the entire buffer

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68701b21ee1c832d9e3338a46ec4a2ef