### PR TITLE
Fix pin toggle keybinding in VS Code settings

### DIFF
--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -297,9 +297,9 @@
     },
     {
       "before": ["<leader>", "b", "p"],
-      // TODO: This is not working for some reason - fix it
+      // Toggle pin/unpin on the active editor
       "commands": ["workbench.action.unpinEditor"],
-      "when": "activeEditorPinned"
+      "when": "activeEditorIsPinned"
     },
     {
       "before": ["<leader>", "b", "p"],


### PR DESCRIPTION
## Summary
- correct `activeEditorIsPinned` context key
- add note to explain toggle keybinding

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_687041a9fbfc832db137aee7d3b52189