### PR TITLE
Enhance kitty config

### DIFF
--- a/dot_config/kitty/kitty.conf
+++ b/dot_config/kitty/kitty.conf
@@ -1,4 +1,10 @@
+include themes/tokyo-night-storm.conf
+
+# Keep the background black instead of the theme's default
 background #000000
+
+# Slight padding for a cleaner look
+padding_width 8
 
 font_size 18.0
 

--- a/dot_config/kitty/themes/tokyo-night-storm.conf
+++ b/dot_config/kitty/themes/tokyo-night-storm.conf
@@ -1,0 +1,50 @@
+# vim:ft=kitty
+
+## name: Tokyo Night Storm
+## license: MIT
+## author: Folke Lemaitre
+## upstream: https://github.com/folke/tokyonight.nvim/raw/main/extras/kitty/tokyonight_storm.conf
+
+
+background #24283b
+foreground #c0caf5
+selection_background #2e3c64
+selection_foreground #c0caf5
+url_color #73daca
+cursor #c0caf5
+cursor_text_color #24283b
+
+# Tabs
+active_tab_background #7aa2f7
+active_tab_foreground #1f2335
+inactive_tab_background #292e42
+inactive_tab_foreground #545c7e
+#tab_bar_background #1d202f
+
+# Windows
+active_border_color #7aa2f7
+inactive_border_color #292e42
+
+# normal
+color0 #1d202f
+color1 #f7768e
+color2 #9ece6a
+color3 #e0af68
+color4 #7aa2f7
+color5 #bb9af7
+color6 #7dcfff
+color7 #a9b1d6
+
+# bright
+color8  #414868
+color9  #ff899d
+color10 #9fe044
+color11 #faba4a
+color12 #8db0ff
+color13 #c7a9ff
+color14 #a4daff
+color15 #c0caf5
+
+# extended colors
+color16 #ff9e64
+color17 #db4b4b


### PR DESCRIPTION
## Summary
- add Tokyo Night Storm theme for kitty
- reference the theme in `kitty.conf`
- add a little padding for aesthetics
- keep the background black

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_687042874f20832dac009352e83a8bbb