### PR TITLE
Add grep color alias

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -1,3 +1,4 @@
+# shellcheck shell=zsh
 if [[ -o interactive ]]; then
   stty -ixon -ixoff
 fi
@@ -57,3 +58,4 @@ eval "$(zoxide init zsh)"
 alias z='cd'
 alias ll='ls -alh --color=auto'
 alias la='ls -A'
+alias grep="grep --color=auto"


### PR DESCRIPTION
## Summary
- colorize grep output by default
- specify zsh shell for ShellCheck

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`
- `shellcheck dot_zshrc`

------
https://chatgpt.com/codex/tasks/task_e_68704ca35108832dbfce298f01359554