### PR TITLE
Set <leader>v for Visual Block mode

### DIFF
--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -96,6 +96,10 @@
       "after": ["<leader>", "<leader>", "2", "S"]
     },
     {
+      "before": ["<leader>", "v"],
+      "after": ["<C-v>"]
+    },
+    {
       "before": ["<tab>"],
       "commands": ["editor.action.indentLines"]
     },

--- a/dot_config/nvim/lua/config/keymaps.lua
+++ b/dot_config/nvim/lua/config/keymaps.lua
@@ -14,6 +14,9 @@ map("i", "<Down>", "<C-o>gj", { noremap = true, desc = "Move down screen-line (i
 vim.keymap.set("n", "<C-u>", "16k", { noremap = true, desc = "Scroll Up 16 lines" })
 vim.keymap.set("n", "<C-d>", "16j", { noremap = true, desc = "Scroll Down 16 lines" })
 
+-- Enter block visual mode with <leader>v
+vim.keymap.set("n", "<leader>v", "<C-v>", { noremap = true, desc = "Block Visual Mode" })
+
 -- disable horizontal scroll with mouse/trackpad
 for _, mode in ipairs({ "n", "i", "v", "o", "t" }) do
   map(mode, "<ScrollWheelLeft>", "<Nop>", { silent = true, desc = "Disable ← scroll" })

--- a/dot_vsvimrc
+++ b/dot_vsvimrc
@@ -31,6 +31,9 @@ nnoremap <leader> <NOP>
 " Esc removes search highlights automatically
 nnoremap <Esc> :nohl<CR>
 
+" Enter block visual mode with <leader>v
+nnoremap <leader>v <C-v>
+
 " Using arrow keys as they are ok on Kinesis keyboard & use Colemak so hjkl
 " are not in a nice spot
 nnoremap <Left> h


### PR DESCRIPTION
## Summary
- map `<leader>v` to enter Visual Block mode in VsVim
- map `<leader>v` to `<C-v>` in Neovim keymaps
- add same mapping for VS Code Vim extension

## Testing
- `chezmoi apply --dry-run -S . -v`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_6870697491dc832db31cf1862a4c145c