### PR TITLE
Add leader bb mapping for alternate buffer

### DIFF
--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -228,6 +228,10 @@
       "commands": ["workbench.action.closeOtherEditors"]
     },
     {
+      "before": ["<leader>", "b", "b"],
+      "after": ["<C-6>"]
+    },
+    {
       "before": ["<leader>", "w", "f"],
       "commands": ["workbench.action.toggleZenMode"]
     },


### PR DESCRIPTION
## Summary
- map `<leader>bb` to `<C-6>` in VS Code Vim

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_687090fd48a4832d8a40139e7cb17c63