### PR TITLE
Enable VSCode Vim debug shortcuts

### DIFF
--- a/docs/vim-bindings.md
+++ b/docs/vim-bindings.md
@@ -1,6 +1,9 @@
 # VSVim Bindings Cheat Sheet
 
-This guide lists all custom key mappings defined in [`dot_vsvimrc`](../dot_vsvimrc). The `Space` key is the leader and `,` is the local leader.
+This guide lists all custom key mappings defined in [`dot_vsvimrc`](../dot_vsvimrc).
+The `Space` key is the leader and `,` is the local leader.
+Equivalent mappings are configured for the VSCodeVim extension via
+[`dot_config/Code/User/settings.json`](../dot_config/Code/User/settings.json).
 
 ## General
 - `zl` – reload `.vsvimrc`.

--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -365,6 +365,30 @@
       "commands": ["workbench.action.closeOtherEditors"]
     },
     {
+      "before": ["<leader>", "d", "b"],
+      "commands": ["editor.debug.action.toggleBreakpoint"]
+    },
+    {
+      "before": ["<leader>", "d", "d"],
+      "commands": ["workbench.debug.viewlet.action.disableAllBreakpoints"]
+    },
+    {
+      "before": ["<leader>", "d", "e"],
+      "commands": ["workbench.debug.viewlet.action.enableAllBreakpoints"]
+    },
+    {
+      "before": ["<leader>", "d", "r"],
+      "commands": ["workbench.debug.viewlet.action.removeAllBreakpoints"]
+    },
+    {
+      "before": ["<leader>", "d", "a"],
+      "commands": ["workbench.debug.viewlet.action.focusBreakpointsView"]
+    },
+    {
+      "before": ["<leader>", "d", "c"],
+      "commands": ["workbench.action.debug.continue"]
+    },
+    {
       "before": ["<Esc>"],
       "after": ["<Esc>"],
       "commands": [":nohl"]


### PR DESCRIPTION
## Summary
- map debugging keys in VSCode Vim settings
- note VSCode support in docs

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_687128796c88832d9645eaa698cd22d5