### PR TITLE
Add undo break when exiting insert mode

### DIFF
--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -325,6 +325,9 @@
       "commands": [":nohl"]
     }
   ],
+  "vim.insertModeKeyBindings": [
+    { "before": ["<Esc>"], "after": ["<Esc>", "<C-g>u"] }
+  ],
   "vim.visualModeKeyBindings": [
     {
       "before": ["<tab>"],


### PR DESCRIPTION
## Summary
- remove punctuation undo keybindings
- add undo checkpoint when leaving insert mode

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68709ebcb628832dbc94b949037dbca6