### PR TITLE
Install fast CLI replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ wsl --install -d Debian && wsl --set-default Debian && wsl -d Debian -- bash -lc
 All setup scripts install the [Starship](https://starship.rs) prompt for a consistent shell experience.
 On Windows this is installed via winget using the `Starship.Starship` package ID.
 
+## Fast CLI Tools
+
+The setup scripts also install speedy alternatives for common commands:
+
+- `ripgrep` for searching directories quickly
+- `fd` as a faster `find`
+- `bat` as a colorful `cat`
+- `exa` as an improved `ls`
+
 # Mac
 
 ## Custom Alt Tab

--- a/common_apps.txt
+++ b/common_apps.txt
@@ -4,6 +4,7 @@ fd
 fzf
 bat
 delta
+exa
 less
 llvm
 nvim

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -56,6 +56,14 @@ eval "$(zoxide init zsh)"
 
 # Aliases
 alias z='cd'
-alias ll='ls -alh --color=auto'
-alias la='ls -A'
 alias grep="grep --color=auto"
+# Use modern replacements if available
+command -v bat >/dev/null && alias cat='bat'
+if command -v exa >/dev/null; then
+  alias ls='exa --color=auto --group-directories-first'
+  alias ll='exa -al --color=auto --group-directories-first'
+  alias la='exa -a --color=auto --group-directories-first'
+fi
+if [[ -z $(command -v fd 2>/dev/null) && -n $(command -v fdfind 2>/dev/null) ]]; then
+  alias fd='fdfind'
+fi

--- a/windows/run_once_30-setup.ps1.tmpl
+++ b/windows/run_once_30-setup.ps1.tmpl
@@ -17,6 +17,7 @@ if (Get-Command winget -ErrorAction SilentlyContinue) {
         'fzf'      = 'junegunn.fzf'
         'bat'      = 'sharkdp.bat'
         'delta'    = 'dandavison.delta'
+        'exa'      = 'ogham.exa'
         'less'     = 'jftuga.less'
         'llvm'     = 'LLVM.LLVM'
         'nvim'     = 'Neovim.Neovim'


### PR DESCRIPTION
## Summary
- add `exa` to common apps
- map `exa` for Windows winget install
- alias `bat`, `exa` and `fd` in zshrc
- document fast CLI tool setup

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_68717b30df24832dbe6687792ee6dae4