### PR TITLE
Fix tmux alt prefix

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -5,9 +5,12 @@ bind-key   r  source-file ~/.tmux.conf
 # Primary prefix (default)
 set -g prefix C-b
 
-# Alternate prefixes
-bind-key -n M-a  send-prefix
+# Secondary prefix
+set -g prefix2 M-a
 bind-key -n S-F2 send-prefix
+
+# Reduce delay when using Alt-based keys
+set -s escape-time 0
 
 # Optional: double-tap Ctrl-b to send a literal C-b
 bind-key C-b send-prefix


### PR DESCRIPTION
## Summary
- make Alt+a a proper secondary prefix
- reduce escape-time for better Alt handling

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68718d0e8988832dad2cc8e31780515a