### PR TITLE
Fix VS Code config

### DIFF
--- a/dot_config/Code/User/keybindings.json
+++ b/dot_config/Code/User/keybindings.json
@@ -24,7 +24,7 @@
                 "scrollLineDown",
                 "cursorDown",
                 "scrollLineDown",
-                "cursorDown",
+                "cursorDown"
         ]
         }
     },
@@ -53,7 +53,7 @@
                 "scrollLineUp",
                 "cursorUp",
                 "scrollLineUp",
-                "cursorUp",
+                "cursorUp"
         ]
         }
     },
@@ -106,7 +106,7 @@
             "scrollLineUp",
             "cursorUp",
             "scrollLineUp",
-            "cursorUp",
+            "cursorUp"
             ]
         }
     },
@@ -149,7 +149,7 @@
             "scrollLineDown",
             "cursorDown",
             "scrollLineDown",
-            "cursorDown",
+            "cursorDown"
             ]
         }
     },
@@ -210,7 +210,7 @@
         "command": "deleteFile",
         "key": "d",
         "when": "filesExplorerFocus && !inputFocus"
-    },
+    }
     // // Extra
     // {
     //     "key": "ctrl+shift+5",


### PR DESCRIPTION
## Summary
- clean up trailing commas in keybindings

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68718c7cf80c832dab93868d43b37b73