### PR TITLE
Add command duration module

### DIFF
--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -12,3 +12,8 @@ success_symbol = '[➜](bold green)' # The 'success_symbol' segment is being set
 # Disable the package module, hiding it from the prompt completely
 [package]
 disabled = true
+
+# Show how long each command took to run if it exceeded 1 second
+[cmd_duration]
+min_time = 1000
+show_milliseconds = true


### PR DESCRIPTION
## Summary
- show how long each command takes when over a second

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68718ea269c4832db85f486e68e1d3e5