### PR TITLE
Replace exa with eza

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The setup scripts also install speedy alternatives for common commands:
 - `ripgrep` for searching directories quickly
 - `fd` as a faster `find`
 - `bat` as a colorful `cat`
-- `exa` as an improved `ls`
+- `eza` as an improved `ls`
 
 # Mac
 

--- a/common_apps.txt
+++ b/common_apps.txt
@@ -4,7 +4,7 @@ fd
 fzf
 bat
 delta
-exa
+eza
 less
 llvm
 nvim

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -92,10 +92,10 @@ alias z='cd'
 alias grep="grep --color=auto"
 # Use modern replacements if available
 command -v bat >/dev/null && alias cat='bat'
-if command -v exa >/dev/null; then
-  alias ls='exa --color=auto --group-directories-first'
-  alias ll='exa -al --color=auto --group-directories-first'
-  alias la='exa -a --color=auto --group-directories-first'
+if command -v eza >/dev/null; then
+  alias ls='eza --color=auto --group-directories-first'
+  alias ll='eza -al --color=auto --group-directories-first'
+  alias la='eza -a --color=auto --group-directories-first'
 fi
 if [[ -z $(command -v fd 2>/dev/null) && -n $(command -v fdfind 2>/dev/null) ]]; then
   alias fd='fdfind'

--- a/windows/run_once_30-setup.ps1.tmpl
+++ b/windows/run_once_30-setup.ps1.tmpl
@@ -17,7 +17,7 @@ if (Get-Command winget -ErrorAction SilentlyContinue) {
         'fzf'      = 'junegunn.fzf'
         'bat'      = 'sharkdp.bat'
         'delta'    = 'dandavison.delta'
-        'exa'      = 'ogham.exa'
+        'eza'      = 'eza-community.eza'
         'less'     = 'jftuga.less'
         'llvm'     = 'LLVM.LLVM'
         'nvim'     = 'Neovim.Neovim'


### PR DESCRIPTION
## Summary
- switch to `eza` in README and dotfiles
- update Windows setup script to install `eza`
- adjust common app list

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_687191d9a558832db8779b4992fb8ddc