### PR TITLE
Fix plugin loading loop in zshrc

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -44,7 +44,7 @@ for plugin in zsh-autosuggestions zsh-syntax-highlighting; do
   for dir in "/usr/local/share/$plugin" "/opt/homebrew/share/$plugin" "/usr/share/$plugin"; do
     if [[ -r "$dir/$plugin.zsh" ]]; then
       source "$dir/$plugin.zsh"
-      break 2
+      break
     fi
   done
 done


### PR DESCRIPTION
## Summary
- ensure both `zsh-autosuggestions` and `zsh-syntax-highlighting` load by exiting only the inner loop

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_687190806b58832db7f43226ba1f9fd7