### PR TITLE
Fix quoting in Linux setup script

### DIFF
--- a/linux/run_once_30-setup.sh.tmpl
+++ b/linux/run_once_30-setup.sh.tmpl
@@ -54,9 +54,9 @@ fi
 # Final debug check
 echo "=== FINAL DEBUG ==="
 for pkg in "${COMMON_APPS[@]}"; do
-    echo "which $pkg: $(which $pkg 2>/dev/null || echo 'not found')"
-    if command -v $pkg >/dev/null 2>&1; then
-        echo "$pkg version: $($pkg --version 2>/dev/null | head -1 || echo 'version not available')"
+    echo "which $pkg: $(which "$pkg" 2>/dev/null || echo 'not found')"
+    if command -v "$pkg" >/dev/null 2>&1; then
+        echo "$pkg version: $("$pkg" --version 2>/dev/null | head -1 || echo 'version not available')"
     fi
 done
 


### PR DESCRIPTION
## Summary
- quote `which` and `command -v` usage in Linux setup script

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_6871908bd78c832d89a75861a0436e32