### PR TITLE
Add Cursor symlinks for VS Code config

### DIFF
--- a/AppData/Roaming/Cursor/User/symlink_keybindings.json.tmpl
+++ b/AppData/Roaming/Cursor/User/symlink_keybindings.json.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.config/Code/User/keybindings.json

--- a/AppData/Roaming/Cursor/User/symlink_settings.json.tmpl
+++ b/AppData/Roaming/Cursor/User/symlink_settings.json.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.config/Code/User/settings.json

--- a/Library/Application Support/Cursor/User/symlink_keybindings.json.tmpl
+++ b/Library/Application Support/Cursor/User/symlink_keybindings.json.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.config/Code/User/keybindings.json

--- a/Library/Application Support/Cursor/User/symlink_settings.json.tmpl
+++ b/Library/Application Support/Cursor/User/symlink_settings.json.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.config/Code/User/settings.json

--- a/docs/vim-bindings.md
+++ b/docs/vim-bindings.md
@@ -3,7 +3,8 @@
 This guide lists all custom key mappings defined in [`dot_vsvimrc`](../dot_vsvimrc).
 The `Space` key is the leader and `,` is the local leader.
 Equivalent mappings are configured for the VSCodeVim extension via
-[`dot_config/Code/User/settings.json`](../dot_config/Code/User/settings.json).
+[`dot_config/Code/User/settings.json`](../dot_config/Code/User/settings.json),
+which is also symlinked for use by the Cursor editor.
 
 ## General
 - `zl` – reload `.vsvimrc`.

--- a/dot_config/Cursor/User/symlink_keybindings.json.tmpl
+++ b/dot_config/Cursor/User/symlink_keybindings.json.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.config/Code/User/keybindings.json

--- a/dot_config/Cursor/User/symlink_settings.json.tmpl
+++ b/dot_config/Cursor/User/symlink_settings.json.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.config/Code/User/settings.json


### PR DESCRIPTION
## Summary
- apply VS Code settings and keybindings to Cursor editor via symlinks
- update docs to mention Cursor usage

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_6871b832cb48832d823137af028f4e6b