### PR TITLE
Fix VS Code extension install

### DIFF
--- a/run_once_40-install-vscode-extensions.ps1.tmpl
+++ b/run_once_40-install-vscode-extensions.ps1.tmpl
@@ -1,14 +1,18 @@
 {{ if eq .chezmoi.os "windows" -}}
 $extensionsFile = "{{ .chezmoi.sourceDir }}\vscode_extensions.txt"
-if (-not (Get-Command "code" -ErrorAction SilentlyContinue)) {
-    Write-Host "VS Code 'code' command not found, skipping extension install"
+if (Get-Command "code" -ErrorAction SilentlyContinue) {
+    $codeCmd = "code"
+} elseif (Get-Command "cursor" -ErrorAction SilentlyContinue) {
+    $codeCmd = "cursor"
+} else {
+    Write-Host "VS Code 'code' or 'cursor' command not found, skipping extension install"
     return
 }
 Get-Content $extensionsFile | ForEach-Object {
     $ext = $_.Trim()
     if ($ext) {
         Write-Host "Installing VS Code extension: $ext"
-        code --install-extension $ext --force
+        & $codeCmd --install-extension $ext --force
     }
 }
 {{ end -}}

--- a/run_once_40-install-vscode-extensions.sh.tmpl
+++ b/run_once_40-install-vscode-extensions.sh.tmpl
@@ -2,13 +2,17 @@
 #!/usr/bin/env bash
 set -e
 EXT_FILE="{{ .chezmoi.sourceDir }}/vscode_extensions.txt"
-if ! command -v code >/dev/null 2>&1; then
-    echo "VS Code 'code' command not found, skipping extension install"
+if command -v code >/dev/null 2>&1; then
+    CODE_CMD="code"
+elif command -v cursor >/dev/null 2>&1; then
+    CODE_CMD="cursor"
+else
+    echo "VS Code 'code' or 'cursor' command not found, skipping extension install"
     exit 0
 fi
 while IFS= read -r ext || [ -n "$ext" ]; do
     [ -z "$ext" ] && continue
     echo "Installing VS Code extension: $ext"
-    code --install-extension "$ext" --force || true
+    "$CODE_CMD" --install-extension "$ext" --force || true
 done < "$EXT_FILE"
 {{ end -}}


### PR DESCRIPTION
## Summary
- support installing extensions with the `cursor` command

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`
- `shellcheck run_once_40-install-vscode-extensions.sh.tmpl`


------
https://chatgpt.com/codex/tasks/task_e_6871c39e5a20832d8aed289769b90284