### PR TITLE
Remove Tokyo Night VS Code extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ P4DIFF="C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\d
 I'm using a few plugins:
 - Vim
 - Find it Faster (hooks into fzf, rg & bat)
-- Tokyo Night Frameless (nice theme)
 Extensions listed in `vscode_extensions.txt` will be installed automatically
 when these dotfiles are applied.
 ```

--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -571,7 +571,6 @@
     "vscodevim.vim": 1
   },
   "workbench.colorTheme": "Visual Studio Dark",
-  // "workbench.colorTheme": "Tokyo Night Frameless",
   "window.titleBarStyle": "custom",
 
   "editor.minimap.enabled": false,

--- a/vscode_extensions.txt
+++ b/vscode_extensions.txt
@@ -1,4 +1,3 @@
 vscodevim.vim
 jellydn.find-it-faster
-enkia.tokyo-night
 esbenp.prettier-vscode


### PR DESCRIPTION
## Summary
- remove Tokyo Night extension from `vscode_extensions.txt`
- drop mention of the theme from the README
- clean up VS Code settings

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_6871be1d2424832dbe199128136f56bb