### PR TITLE
Improve Linux install snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ chezmoi init --apply skyde
 ### Linux
 
 ```
-sudo apt-get update -qq && sudo apt-get install -y curl && \
+sudo apt-get update -qq && sudo apt-get install -y curl git && \
 mkdir -p ~/.local/bin && \
 echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc && export PATH="$HOME/.local/bin:$PATH" && \
 curl -fsSL get.chezmoi.io | BINDIR="$HOME/.local/bin" bash -s -- init --apply skyde


### PR DESCRIPTION
## Summary
- install `git` alongside `curl` when setting up chezmoi on Linux

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68725b072b8c832d80e2dd5d425a995c