### PR TITLE
Add clangd VS Code extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ P4DIFF="C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\d
 I'm using a few plugins:
 - Vim
 - Find it Faster (hooks into fzf, rg & bat)
+- clangd for C++ language features
 Extensions listed in `vscode_extensions.txt` will be installed automatically
 when these dotfiles are applied. Custom keybindings are documented in
 [`docs/vscode-keybindings.md`](docs/vscode-keybindings.md).

--- a/vscode_extensions.txt
+++ b/vscode_extensions.txt
@@ -3,3 +3,4 @@ tomrijndorp.find-it-faster
 jeff-hykin.better-cpp-syntax
 ms-vscode.cpptools-themes
 esbenp.prettier-vscode
+llvm-vs-code-extensions.vscode-clangd


### PR DESCRIPTION
## Summary
- install the `clangd` extension for VS Code
- mention clangd in documentation

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_6872d719146c832d91eb09c387b2fe62