### PR TITLE
Fix contextual VSCode keybindings

### DIFF
--- a/docs/vscode-keybindings.md
+++ b/docs/vscode-keybindings.md
@@ -116,10 +116,10 @@ The following shortcuts are configured through the VS Code Vim extension via [`s
 - `<leader> m c` – workbench.action.tasks.terminate
 - `<leader> m r` – workbench.action.debug.start
 - `<leader> m s` – workbench.action.debug.stop
-- `J` – workbench.action.debug.setNextStatement
-- `H` – workbench.action.debug.stepOver
-- `L` – workbench.action.debug.stepInto
-- `K` – workbench.action.debug.stepOut
+- `J` – debug.setNextStatement / merge-conflict.accept.incoming / cursorDown
+- `H` – debug.stepOver / merge.goToNextUnhandledConflict / cursorLeft
+- `L` – debug.stepInto / merge.goToPreviousUnhandledConflict / cursorRight
+- `K` – debug.stepOut / merge-conflict.accept.current / cursorUp
 ### Insert Mode
 
 - `<Esc>` – <Esc> <C-g>u

--- a/dot_config/Code/User/keybindings.json
+++ b/dot_config/Code/User/keybindings.json
@@ -210,6 +210,69 @@
         "command": "deleteFile",
         "key": "d",
         "when": "filesExplorerFocus && !inputFocus"
+    },
+    // ─── Debug navigation (active only when paused) ─────────
+    {
+        "key": "J",
+        "command": "workbench.action.debug.setNextStatement",
+        "when": "inDebugMode && debugState == 'stopped' && editorTextFocus"
+    },
+    {
+        "key": "H",
+        "command": "workbench.action.debug.stepOver",
+        "when": "inDebugMode && debugState == 'stopped' && editorTextFocus"
+    },
+    {
+        "key": "L",
+        "command": "workbench.action.debug.stepInto",
+        "when": "inDebugMode && debugState == 'stopped' && editorTextFocus"
+    },
+    {
+        "key": "K",
+        "command": "workbench.action.debug.stepOut",
+        "when": "inDebugMode && debugState == 'stopped' && editorTextFocus"
+    },
+    // ─── Merge-editor helpers (only inside a conflict) ──────
+    {
+        "key": "J",
+        "command": "merge-conflict.accept.incoming",
+        "when": "mergeConflict && editorTextFocus"
+    },
+    {
+        "key": "K",
+        "command": "merge-conflict.accept.current",
+        "when": "mergeConflict && editorTextFocus"
+    },
+    {
+        "key": "H",
+        "command": "merge.goToNextUnhandledConflict",
+        "when": "mergeConflict && editorTextFocus"
+    },
+    {
+        "key": "L",
+        "command": "merge.goToPreviousUnhandledConflict",
+        "when": "mergeConflict && editorTextFocus"
+    },
+    // ─── Fallback cursor movement ─────────
+    {
+        "key": "J",
+        "command": "cursorDown",
+        "when": "!inDebugMode && !mergeConflict && vim.mode == 'Normal'"
+    },
+    {
+        "key": "K",
+        "command": "cursorUp",
+        "when": "!inDebugMode && !mergeConflict && vim.mode == 'Normal'"
+    },
+    {
+        "key": "H",
+        "command": "cursorLeft",
+        "when": "!inDebugMode && !mergeConflict && vim.mode == 'Normal'"
+    },
+    {
+        "key": "L",
+        "command": "cursorRight",
+        "when": "!inDebugMode && !mergeConflict && vim.mode == 'Normal'"
     }
     // // Extra
     // {

--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -254,7 +254,11 @@
     "<tab>": false,
     "<S-tab>": false,
     "<C-o>": true,
-    "<C-i>": true
+    "<C-i>": true,
+    "J": false,
+    "H": false,
+    "K": false,
+    "L": false
   },
   // Search behaviour like Vim
   "vim.ignorecase": true,
@@ -635,27 +639,8 @@
     {
       "before": ["<leader>", "m", "s"],
       "commands": ["workbench.action.debug.stop"]
-    },
-    // Debug Navigation
-    // Note these are optimized for Colemak so you may want to use a different order on QWERTY
-    {
-      // Goto specified spot
-      // "before": ["<Leader>", "d", "g"],
-      "before": ["J"],
-      "commands": ["workbench.action.debug.setNextStatement"]
-    },
-    {
-      "before": ["H"],
-      "commands": ["workbench.action.debug.stepOver"]
-    },
-    {
-      "before": ["L"],
-      "commands": ["workbench.action.debug.stepInto"]
-    },
-    {
-      "before": ["K"],
-      "commands": ["workbench.action.debug.stepOut"]
     }
+    // Debug Navigation removed; handled via keybindings.json
   ],
   "vim.insertModeKeyBindings": [
     // Manually create undo stack


### PR DESCRIPTION
## Summary
- allow VSCode to handle J/H/K/L so they can depend on context
- move debug and merge-conflict actions to `keybindings.json`
- document context aware J/H/K/L behaviour

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_687326e5b58c832d987e1e499a418f15