### PR TITLE
Sync VSCode and VsVim debug keys

### DIFF
--- a/docs/vim-bindings.md
+++ b/docs/vim-bindings.md
@@ -50,6 +50,16 @@ which is also symlinked for use by the Cursor editor.
 - `<leader>gh` – file history.
 - `<leader>gt` – timelapse view.
 
+## Merge Conflicts
+- `Alt+K` – accept current change.
+- `Shift+Alt+K` – accept all current changes.
+- `Alt+J` – accept incoming change.
+- `Shift+Alt+J` – accept all incoming changes.
+- `Alt+H` – go to next unhandled conflict.
+- `Shift+Alt+H` – go to next conflict region.
+- `Alt+L` – go to previous unhandled conflict.
+- `Shift+Alt+L` – go to previous conflict region.
+
 ## Refactoring and Errors
 - `<leader>ce` – Resharper quick fix.
 - `<leader>.` – quick actions for position.
@@ -96,10 +106,10 @@ which is also symlinked for use by the Cursor editor.
 - `<leader>da` – list breakpoints.
 - `<leader>dc` – continue debugging.
 - `<leader>dw` – QuickWatch dialog.
-- `J` – set next statement.
-- `H` – step over.
-- `L` – step into.
-- `K` – step out.
+- `<leader>dg` – run to cursor.
+- `Alt+H` – step over.
+- `Alt+L` – step into.
+- `Alt+K` – step out.
 
 ## Hardware Macro Keys
 These key combinations are implemented via keyboard macros rather than in `dot_vsvimrc`:

--- a/dot_vsvimrc
+++ b/dot_vsvimrc
@@ -206,11 +206,21 @@ nnoremap <Leader>dw :vsc Debug.QuickWatch<CR>
 " TODO: Look into how these debug commands are setup - maybe Ctrl+ArrowKey
 " would be a better way to do it?
 
-" J runs the program to the highlighted line
-nnoremap J :vsc Debug.SetNextStatement<CR>
-" H steps the program once
-nnoremap H :vsc Debug.StepOver<CR>
-" L steps into the current statement
-nnoremap L :vsc Debug.StepInto<CR>
-" K steps out of the current context
-nnoremap K :vsc Debug.StepOut<CR>
+" Run to cursor
+nnoremap <leader>dg :vsc Debug.SetNextStatement<CR>
+" Step over / next difference
+nnoremap <A-h> :vsc Debug.StepOver<CR>:vsc Diff.NextDifference<CR>
+" Step into / previous difference
+nnoremap <A-l> :vsc Debug.StepInto<CR>:vsc Diff.PreviousDifference<CR>
+" Step out / accept current change
+nnoremap <A-k> :vsc Debug.StepOut<CR>:vsc TeamFoundationContextMenus.MergeContextMenu.AcceptYours<CR>
+" Accept incoming change
+nnoremap <A-j> :vsc TeamFoundationContextMenus.MergeContextMenu.AcceptTheirs<CR>
+" Accept all current changes
+nnoremap <S-A-k> :vsc TeamFoundationContextMenus.MergeContextMenu.AcceptAllYours<CR>
+" Accept all incoming changes
+nnoremap <S-A-j> :vsc TeamFoundationContextMenus.MergeContextMenu.AcceptAllTheirs<CR>
+" Next conflict region
+nnoremap <S-A-h> :vsc Diff.NextDifference<CR>
+" Previous conflict region
+nnoremap <S-A-l> :vsc Diff.PreviousDifference<CR>


### PR DESCRIPTION
## Summary
- add Alt-based debug and merge mappings in `dot_vsvimrc`
- document the new shortcuts in `docs/vim-bindings.md`

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_6873b0386ad4832d9ffb61d377a8e017