### PR TITLE
Add Copilot Chat vim key mappings

### DIFF
--- a/docs/vscode-keybindings.md
+++ b/docs/vscode-keybindings.md
@@ -25,6 +25,9 @@ This document lists all custom shortcuts defined in [`dot_config/Code/User/keybi
 - `Shift+O` – create a new folder.
 - `d` – delete the selected file.
 
+## Copilot Chat
+- `Escape` – close Copilot Chat when focused.
+
 ## Merge Conflicts
 - `Alt+K` – accept current change.
 - `Shift+Alt+K` – accept all current changes.
@@ -58,6 +61,7 @@ The following shortcuts are configured through the VS Code Vim extension via [`s
 - `<C-r>` – redo
 - `<C-l>` – workbench.action.focusRightGroup
 - `<leader> <leader>` – workbench.action.quickOpen
+- `<leader> a` – workbench.action.chat.open
 - `<leader> f m` – workbench.files.action.focusFilesExplorer
 - `<leader> e` – workbench.view.explorer
 - `] b` – workbench.action.nextEditor

--- a/dot_config/Code/User/keybindings.json
+++ b/dot_config/Code/User/keybindings.json
@@ -236,6 +236,12 @@
     "key": "e",
     "when": "explorerViewletVisible && !inputFocus"
   },
+  // Copilot Chat
+  {
+    "command": "workbench.action.toggleAuxiliaryBar",
+    "key": "escape",
+    "when": "interactiveSessionFocus && auxiliaryBarVisible && !inputFocus"
+  },
   {
     "key": "o",
     "command": "explorer.newFile",

--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -338,6 +338,11 @@
       "before": ["<leader>", "<leader>"],
       "commands": ["workbench.action.quickOpen"]
     },
+    // Copilot Chat
+    {
+      "before": ["<leader>", "a"],
+      "commands": ["workbench.action.chat.open"]
+    },
     // File
     {
       "before": ["<leader>", "f", "m"],


### PR DESCRIPTION
## Summary
- add `<leader>a` mapping to open Copilot Chat
- allow `Escape` to close Copilot Chat when focused
- document new shortcuts

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_6876731e3fd8832d912dd785a7fbe1c7