### PR TITLE
Add VSCode Vim mapping for file path copy

### DIFF
--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -347,6 +347,10 @@
       "before": ["<leader>", "f", "r"],
       "commands": ["workbench.action.openRecent"]
     },
+    {
+      "before": ["<leader>", "f", "l"],
+      "commands": ["copyFilePath"]
+    },
     // Explorer
     {
       "before": ["<leader>", "e"],


### PR DESCRIPTION
## Summary
- map `<leader>fl` in VSCode Vim to the `copyFilePath` command

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_687673962500832d84df7e864f3646c0