### PR TITLE
Enable hard mode toggle in Neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ I'm using a few plugins:
 - Vim
 - Find it Faster (hooks into fzf, rg & bat)
 - clangd for C++ language features
+- [hardtime.nvim](https://github.com/m4xshen/hardtime.nvim) for Hard Mode (toggle with `<leader>uh`)
 Extensions listed in `vscode_extensions.txt` will be installed automatically
 when these dotfiles are applied. Custom keybindings are documented in
 [`docs/vscode-keybindings.md`](docs/vscode-keybindings.md).

--- a/docs/vim-bindings.md
+++ b/docs/vim-bindings.md
@@ -21,6 +21,7 @@ which is also symlinked for use by the Cursor editor.
 - `<` / `>` in visual mode keep selection when indenting.
 - `<leader><leader>` – ReSharper goto file.
 - `<C-s>` – format document and save (works in all modes).
+- `<leader>uh` – toggle Hard Mode.
 
 ## File Operations
 - `<leader>fm` – open containing folder.

--- a/dot_config/nvim/lua/plugins/hardtime.lua
+++ b/dot_config/nvim/lua/plugins/hardtime.lua
@@ -1,0 +1,14 @@
+return {
+  "m4xshen/hardtime.nvim",
+  event = "VeryLazy",
+  opts = {},
+  keys = {
+    {
+      "<leader>uh",
+      function()
+        vim.cmd("Hardtime toggle")
+      end,
+      desc = "Toggle Hard Mode",
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- add `hardtime.nvim` plugin
- document `<leader>uh` in vim bindings cheat sheet
- mention Hardtime in README

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_6877954d3e80832db50779a3f0ed6d78