### PR TITLE
Disable zsh command correction

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -16,7 +16,8 @@ export VISUAL="$EDITOR"
 
 # Shell Options
 setopt autocd             # Enter directory just by typing its name
-setopt correct            # Auto correct command typos
+# Disable automatic command correction
+# setopt correct
 setopt nocaseglob         # Case insensitive globbing
 setopt extended_glob      # Extended globbing
 setopt hist_ignore_all_dups  # Don’t store duplicate history


### PR DESCRIPTION
## Summary
- disable automatic zsh correction by commenting out `setopt correct`

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68771269f78c832d964c8b617ce00c2d