### PR TITLE
Remove curl usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,25 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install chezmoi (Unix)
+      - name: Ensure chezmoi is installed (Unix)
         if: runner.os != 'Windows'
-        run: sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
+        shell: bash
+        run: |
+          if ! command -v chezmoi >/dev/null; then
+            echo "chezmoi not found. Attempting to install via package manager"
+            sudo apt-get update && sudo apt-get install -y chezmoi || brew install chezmoi || {
+              echo "chezmoi is required. Install it manually." && exit 1
+            }
+          fi
 
-      - name: Install chezmoi (Windows)
+      - name: Ensure chezmoi is installed (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $binDir = "$env:USERPROFILE\bin"
-          iex "& { $(iwr -useb https://get.chezmoi.io/ps1) } -b $binDir"
-          "$binDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          if (-not (Get-Command chezmoi -ErrorAction SilentlyContinue)) {
+            Write-Host 'chezmoi not found. Attempting winget install.'
+            winget install twpayne.chezmoi -e --id twpayne.chezmoi || throw 'chezmoi is required. Install it manually.'
+          }
 
 
       - name: Dry-run apply

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,7 @@ Follow these rules whenever you make changes:
 1. Run `chezmoi apply --dry-run -S .` and ensure it finishes without errors.
 2. Run `chezmoi doctor -S .` and confirm all tests pass.
 
-If `chezmoi` is missing, install it using:
-`curl -fsLS get.chezmoi.io | bash -s -- -b /usr/local/bin`
+If `chezmoi` is missing, install it via your package manager or from https://github.com/twpayne/chezmoi.
 
 ## Optional checks
 - If `shellcheck` is available, run it on any modified shell scripts.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### Mac
 
 ```sh
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+# Install Homebrew from https://brew.sh if it's not already present
 brew install chezmoi
 chezmoi init --apply skyde
 ```
@@ -11,10 +11,8 @@ chezmoi init --apply skyde
 ### Linux
 
 ```
-sudo apt-get update -qq && sudo apt-get install -y curl git && \
-mkdir -p ~/.local/bin && \
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc && export PATH="$HOME/.local/bin:$PATH" && \
-curl -fsSL get.chezmoi.io | BINDIR="$HOME/.local/bin" bash -s -- init --apply skyde
+sudo apt-get update -qq && sudo apt-get install -y git chezmoi
+chezmoi init --apply skyde
 ```
 
 ### Windows
@@ -29,13 +27,13 @@ chezmoi init --apply skyde
 Try it yourself in a Docker container.
 
 ```sh
-docker run --rm -it debian:testing bash -c 'apt update && apt install -y curl git && curl -fsSL get.chezmoi.io | bash -s -- init --apply skyde && exec bash'
+docker run --rm -it debian:testing bash -c 'apt update && apt install -y git chezmoi && chezmoi init --apply skyde && exec bash'
 ```
 
 ### WSL Installation
 
 ```ps
-wsl --install -d Debian && wsl --set-default Debian && wsl -d Debian -- bash -lc 'sudo sed -i "s/bookworm/trixie/g" /etc/apt/sources.list && sudo apt update && sudo apt full-upgrade -y && curl -fsLS get.chezmoi.io | bash -s -- init --apply skyde'
+wsl --install -d Debian && wsl --set-default Debian && wsl -d Debian -- bash -lc 'sudo sed -i "s/bookworm/trixie/g" /etc/apt/sources.list && sudo apt update && sudo apt full-upgrade -y && sudo apt install -y chezmoi && chezmoi init --apply skyde'
 ```
 
 ## Starship Prompt

--- a/darwin/run_once_30-setup.sh.tmpl
+++ b/darwin/run_once_30-setup.sh.tmpl
@@ -9,18 +9,14 @@ echo "Running macOS setup using Homebrew..."
 
 # Check if Homebrew is installed
 if ! command -v brew >/dev/null 2>&1; then
-    echo "Installing Homebrew..."
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-    # Add Homebrew to PATH for Apple Silicon Macs
+    echo "Homebrew not found. Please install it from https://brew.sh"
+else
     if [[ $(uname -m) == "arm64" ]]; then
         echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
         eval "$(/opt/homebrew/bin/brew shellenv)"
     fi
+    brew update
 fi
-
-# Update Homebrew
-brew update
 
 echo "Installing common apps..."
 # Install common apps


### PR DESCRIPTION
## Summary
- update Mac/Linux install instructions to avoid curl
- warn when Homebrew isn't installed on macOS setup
- use package manager for CI chezmoi install
- update agent instructions

## Testing
- `apt-get install -y chezmoi` *(fails: Unable to locate package)*
- `chezmoi apply --dry-run -S .` *(fails: command not found)*
- `chezmoi doctor -S .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68786181bda4832d922e2f386ad1b9db