### PR TITLE
Add leader fn VS Code shortcut

### DIFF
--- a/docs/vscode-keybindings.md
+++ b/docs/vscode-keybindings.md
@@ -63,6 +63,7 @@ The following shortcuts are configured through the VS Code Vim extension via [`s
 - `<leader> <leader>` – workbench.action.quickOpen
 - `<leader> a` – workbench.action.chat.open
 - `<leader> f m` – workbench.files.action.focusFilesExplorer
+- `<leader> f n` – workbench.action.files.newUntitledFile
 - `<leader> e` – workbench.view.explorer
 - `] b` – workbench.action.nextEditor
 - `[ b` – workbench.action.previousEditor

--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -347,6 +347,10 @@
       "before": ["<leader>", "f", "l"],
       "commands": ["copyFilePath"]
     },
+    {
+      "before": ["<leader>", "f", "n"],
+      "commands": ["workbench.action.files.newUntitledFile"]
+    },
     // Explorer
     {
       "before": ["<leader>", "e"],


### PR DESCRIPTION
## Summary
- map `<leader> f n` to open a new untitled file in VS Code
- document the new shortcut in the keybindings cheat sheet

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_687941cb2ea4832da04893b881ed66cc