### PR TITLE
Map leader ce to trigger completion

### DIFF
--- a/docs/vscode-keybindings.md
+++ b/docs/vscode-keybindings.md
@@ -102,7 +102,7 @@ The following shortcuts are configured through the VS Code Vim extension via [`s
 - `d i g` – g g V G d
 - `<leader> c r` – editor.action.rename
 - `<leader> c i` – editor.action.triggerParameterHints
-- `<leader> c e` – editor.action.quickFix
+- `<leader> c e` – editor.action.triggerSuggest
 - `<leader> e e` – workbench.actions.view.problems
 - `<leader> e n` – editor.action.marker.next
 - `<leader> e p` – editor.action.marker.prev

--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -592,7 +592,7 @@
     },
     {
       "before": ["<leader>", "c", "e"],
-      "commands": ["editor.action.quickFix"]
+      "commands": ["editor.action.triggerSuggest"]
     },
     // Errors
     {


### PR DESCRIPTION
## Summary
- remap `<leader> c e` to open code completion suggestions
- update keybindings doc

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_6879443a8a14832d9b7960ea6c6acbde