### PR TITLE
Fix tmux color sequences on macOS

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -22,7 +22,8 @@ bind-key k select-pane -U
 bind-key l select-pane -R
 
 # Ensure we get nice colors
-set -g default-terminal "tmux-256color"
+# Use a broadly supported terminfo to avoid escape sequence issues on macOS
+set -g default-terminal "screen-256color"
 
 # Don't eat events that the program should receive (though there is still some issue here)
 unbind -n C-s


### PR DESCRIPTION
## Summary
- use `screen-256color` so macOS recognizes the terminfo

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_6879ac45bb84832db5ca6f3ad623ce69