### PR TITLE
Add tab move shortcuts for VSCodeVim

### DIFF
--- a/docs/vscode-keybindings.md
+++ b/docs/vscode-keybindings.md
@@ -73,6 +73,8 @@ The following shortcuts are configured through the VS Code Vim extension via [`s
 - `<leader> b u` – workbench.action.unpinEditor
 - `<leader> b p` – workbench.action.pinEditor
 - `<leader> b P` – workbench.action.closeOtherEditors
+- `<leader> b h` – workbench.action.moveEditorLeftInGroup
+- `<leader> b l` – workbench.action.moveEditorRightInGroup
 - `<S-h>` – :bprevious
 - `<S-l>` – :bnext
 - `<leader> w f` – workbench.action.toggleZenMode

--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -374,6 +374,16 @@
       "commands": ["workbench.action.previousEditor"]
     },
     {
+      // Move tab left
+      "before": ["<leader>", "b", "h"],
+      "commands": ["workbench.action.moveEditorLeftInGroup"]
+    },
+    {
+      // Move tab right
+      "before": ["<leader>", "b", "l"],
+      "commands": ["workbench.action.moveEditorRightInGroup"]
+    },
+    {
       // Close current tab
       "before": ["<leader>", "b", "d"],
       "commands": [

--- a/dot_config/nvim/lua/config/keymaps.lua
+++ b/dot_config/nvim/lua/config/keymaps.lua
@@ -104,3 +104,7 @@ vim.keymap.del("n", "<S-l>")
 -- map("n", "<D-S-]>", ":bnext<CR>", { desc = "Next buffer" })
 -- Previous buffer: Cmd+Shift+[
 -- map("n", "<D-S-[>", ":bprevious<CR>", { desc = "Previous buffer" })
+
+-- Move tab left/right
+map("n", "<leader>bh", "<cmd>tabmove -1<CR>", { desc = "Move tab left" })
+map("n", "<leader>bl", "<cmd>tabmove +1<CR>", { desc = "Move tab right" })


### PR DESCRIPTION
## Summary
- map `<leader>bh` and `<leader>bl` in VSCode to shift tabs left and right
- document the new VSCode keybindings
- add matching Neovim mappings using `:tabmove`

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_687a61cc7670832db4c0fcb721882f5a