### PR TITLE
Update VSCode Vim keymap for Yazi

### DIFF
--- a/docs/vim-bindings.md
+++ b/docs/vim-bindings.md
@@ -23,7 +23,8 @@ which is also symlinked for use by the Cursor editor.
 - `<C-s>` – format document and save (works in all modes).
 
 ## File Operations
-- `<leader>fm` – open containing folder.
+- `<leader>fm` – open [Yazi](https://github.com/sxyazi/yazi) in the terminal at the current file.
+- `<leader>fM` – open containing folder.
 - `<leader>r` – open terminal window.
 - `<leader>e` – show Solution Explorer.
 

--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -337,6 +337,16 @@
     // File
     {
       "before": ["<leader>", "f", "m"],
+      "commands": [
+        "workbench.action.terminal.focus",
+        {
+          "command": "workbench.action.terminal.sendSequence",
+          "args": { "text": "yazi \"${file}\"\u000D" }
+        }
+      ]
+    },
+    {
+      "before": ["<leader>", "f", "M"],
       "commands": ["revealFileInOS"]
     },
     {


### PR DESCRIPTION
## Summary
- map `<leader>fM` to open containing folder in VSCode Vim
- keep `<leader>fm` for Yazi
- document the new `fM` binding in `vim-bindings.md`

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_687ac1733718832db0284860ac9d5ff6