### PR TITLE
Fix Yazi keymap override

### DIFF
--- a/dot_config/yazi/keymap.toml
+++ b/dot_config/yazi/keymap.toml
@@ -2,7 +2,7 @@
 "$schema" = "https://yazi-rs.github.io/schemas/keymap.json"
 
 [mgr]
-keymap = [
+append_keymap = [
   # Close Yazi similar to toggling the Explorer
   { on = "<Esc>", run = "quit", desc = "Close Yazi" },
   { on = "e",     run = "quit", desc = "Close Yazi" },


### PR DESCRIPTION
## Summary
- keep Yazi defaults by using `append_keymap`

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_687bceb7f3d0832dbce7241fdc127a7c