### PR TITLE
Update Yazi opener for VS Code

### DIFF
--- a/dot_config/yazi/yazi.toml
+++ b/dot_config/yazi/yazi.toml
@@ -4,3 +4,14 @@
 [mgr]
 ratio = [1, 4, 3]
 show_hidden = true
+
+[opener]
+open = [
+  { run = 'code "$@"', orphan = true, desc = 'VS Code', for = 'unix' },
+  { run = 'code %*', orphan = true, desc = 'VS Code', for = 'windows' },
+]
+
+[open]
+rules = [
+  { name = '*', use = [ 'open' ] },
+]


### PR DESCRIPTION
## Summary
- open files from Yazi with VS Code by default

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_687bf95dfdb4832d9d511aadb80a12b1