### PR TITLE
Add git.yazi plugin

### DIFF
--- a/dot_config/yazi/init.lua
+++ b/dot_config/yazi/init.lua
@@ -1,0 +1,1 @@
+require("git"):setup()

--- a/dot_config/yazi/yazi.toml
+++ b/dot_config/yazi/yazi.toml
@@ -15,3 +15,14 @@ open = [
 rules = [
   { name = '*', use = [ 'open' ] },
 ]
+
+[[plugin.prepend_fetchers]]
+id = "git"
+name = "*"
+run = "git"
+
+[[plugin.prepend_fetchers]]
+id = "git"
+name = "*/"
+run = "git"
+


### PR DESCRIPTION
## Summary
- configure yazi to show git status with git.yazi plugin

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_687bff342f28832daf4437eb57cb6a60