### PR TITLE
Fix nvim comment macro

### DIFF
--- a/dot_config/nvim/lua/config/keymaps.lua
+++ b/dot_config/nvim/lua/config/keymaps.lua
@@ -23,8 +23,6 @@ for _, mode in ipairs({ "n", "i", "v", "o", "t" }) do
   map(mode, "<ScrollWheelRight>", "<Nop>", { silent = true, desc = "Disable → scroll" })
 end
 
-
-
 --------------------------------------------------------------------------
 -- Shift+Function key helpers -------------------------------------------
 --------------------------------------------------------------------------
@@ -59,11 +57,9 @@ vim.keymap.set("n", "<leader>uk", print_keys.toggle, {
   desc = "Toggle Key Print",
 })
 
--- Toggle comment on the current line  ── normal mode
-vim.keymap.set("n", "<S-F11>", "gcc", { remap = true, silent = true, desc = "Toggle Comment (line)" })
+map_shift_f(11, "gcc", { remap = true, silent = true, desc = "Toggle Comment (line)" })
 
--- Toggle comment on a visual selection ── visual mode
-vim.keymap.set("x", "<S-F11>", "gc", { remap = true, silent = true, desc = "Toggle Comment (block)" })
+map_shift_f(11, "gc", { mode = "x", remap = true, silent = true, desc = "Toggle Comment (block)" })
 
 -- Reload the current buffer, smart-handling Lua files
 vim.keymap.set("n", "zl", function()


### PR DESCRIPTION
## Summary
- map `<S-F11>` comment key using `map_shift_f` helper for cross-platform compatibility

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`
- `stylua dot_config/nvim/lua/config/keymaps.lua`

------
https://chatgpt.com/codex/tasks/task_e_687c12256f80832dab12e3bc8284932f