### PR TITLE
Add Tab indent keymaps

### DIFF
--- a/dot_config/nvim/lua/config/keymaps.lua
+++ b/dot_config/nvim/lua/config/keymaps.lua
@@ -104,3 +104,9 @@ vim.keymap.del("n", "<S-l>")
 -- Move tab left/right
 map("n", "<leader>bh", "<cmd>tabmove -1<CR>", { desc = "Move tab left" })
 map("n", "<leader>bl", "<cmd>tabmove +1<CR>", { desc = "Move tab right" })
+
+-- Indent with Tab and unindent with Shift+Tab
+map("n", "<Tab>", ">>", { desc = "Indent line" })
+map("n", "<S-Tab>", "<<", { desc = "Unindent line" })
+map("v", "<Tab>", ">gv", { desc = "Indent selection" })
+map("v", "<S-Tab>", "<gv", { desc = "Unindent selection" })


### PR DESCRIPTION
## Summary
- allow Tab and Shift+Tab to indent and unindent in Neovim

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_687c6d02ddac832d9242afcd5f23fdbe