### PR TITLE
Add mappings for browser back/forward keys

### DIFF
--- a/dot_config/nvim/lua/config/keymaps.lua
+++ b/dot_config/nvim/lua/config/keymaps.lua
@@ -83,6 +83,9 @@ map("n", "<A-o>", "<cmd>ClangdSwitchSourceHeader<CR>", { desc = "Switch header/s
 -- Navigate jump list with Alt+Left/Right
 map("n", "<D-Left>", "<C-o>", { desc = "Jump backward" })
 map("n", "<D-Right>", "<C-i>", { desc = "Jump forward" })
+-- Browser-style Forward/Back keys
+map("n", "<Back>", "<C-o>", { desc = "Jump backward" })
+map("n", "<Forward>", "<C-i>", { desc = "Jump forward" })
 
 -- macOS clipboard shortcuts
 map("v", "<D-c>", '"+y', { desc = "Copy selection" })


### PR DESCRIPTION
## Summary
- support dedicated Back/Forward keys in Neovim keymaps

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_687c70668f54832db4671f5c6000911d