### PR TITLE
Add clear-name rename shortcut in yazi

### DIFF
--- a/dot_config/yazi/keymap.toml
+++ b/dot_config/yazi/keymap.toml
@@ -10,9 +10,10 @@ prepend_keymap = [
 	{ on = "x",         run = "yank --cut",                  desc = "Yank selected files (cut)" },
 	{ on = "d",         run = "remove",                      desc = "Trash selected files" },
 	{ on = "D",         run = "remove --permanently",        desc = "Permanently delete selected files" },
-	{ on = "o",         run = "create",                      desc = "Create a file (ends with / for directories)" },
-	{ on = "i",         run = "rename --cursor=before_ext",  desc = "Rename selected file(s)" },
-	{ on = ["<Space>", "<Space>"], run = "search --via=fd",             desc = "Search files by name via fd" },
+        { on = "o",         run = "create",                      desc = "Create a file (ends with / for directories)" },
+        { on = "i",         run = "rename --cursor=before_ext",  desc = "Rename selected file(s)" },
+        { on = "c",         run = "rename --cursor=start --empty=stem", desc = "Change name keeping extension" },
+        { on = ["<Space>", "<Space>"], run = "search --via=fd",             desc = "Search files by name via fd" },
 	{ on = ["<Space>", "s", "f"], run = "search --via=fd",             desc = "Search files by name via fd" },
 	{ on = ["<Space>", "s", "t"],         run = "search --via=rg",             desc = "Search files by content via ripgrep" },
 	{ on = "<Backspace>", run = [ "toggle", "arrow next" ], desc = "Toggle the current selection state" },#


### PR DESCRIPTION
## Summary
- add `c` shortcut to yazi keymap to start renaming with the base name cleared

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_687c7ce92d38832d8895bba59147d158