### PR TITLE
Fix yazi config on Windows

### DIFF
--- a/AppData/Roaming/yazi/symlink_config.tmpl
+++ b/AppData/Roaming/yazi/symlink_config.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.config/yazi

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Allows increased brightness when viewing SDR content on an HDR monitor.
 - Set cursor thickness to 6
 ```
 
+Yazi expects its configuration under `%AppData%\yazi\config` on Windows. These dotfiles create a symlink to `~/.config/yazi` so settings apply across OSes.
+
 ## Powershell 7
 
 Use this since it's nicer than the default one.


### PR DESCRIPTION
## Summary
- symlink `%AppData%\yazi\config` to `~/.config/yazi`
- document Windows yazi config location in README

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_687e4adf4b84832d996a3102220548a0