### PR TITLE
Add Windows tab switching shortcuts

### DIFF
--- a/dot_config/Code/User/keybindings.json
+++ b/dot_config/Code/User/keybindings.json
@@ -439,6 +439,16 @@
         "workbench.action.revertAndCloseActiveEditor"
       ]
     }
+  },
+  {
+    "key": "shift+left",
+    "command": "workbench.action.previousEditor",
+    "when": "isWindows"
+  },
+  {
+    "key": "shift+right",
+    "command": "workbench.action.nextEditor",
+    "when": "isWindows"
   }
   // Terminal
   // {


### PR DESCRIPTION
## Summary
- add Windows-specific keybindings so Shift+Left/Right cycle through tabs

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_687e54cd4934832dbf6b45569b3716b6