### PR TITLE
Add Windows VS Code tab shortcuts

### DIFF
--- a/docs/vscode-keybindings.md
+++ b/docs/vscode-keybindings.md
@@ -7,6 +7,8 @@ This document lists all custom shortcuts defined in [`dot_config/Code/User/keybi
 - `PageUp` – scroll one page up and move the cursor to the bottom of the viewport (matches Vim behavior).
 - `Shift+F4` – scroll up 16 lines.
 - `Shift+F6` – scroll down 16 lines.
+- `Ctrl+Tab` – switch to the next tab (Windows only).
+- `Ctrl+Shift+Tab` – switch to the previous tab (Windows only).
 
 ## Build and Search
 - `Shift+F2` – run the build task.

--- a/dot_config/Code/User/keybindings.json
+++ b/dot_config/Code/User/keybindings.json
@@ -439,6 +439,16 @@
         "workbench.action.revertAndCloseActiveEditor"
       ]
     }
+  },
+  {
+    "key": "ctrl+tab",
+    "command": "workbench.action.nextEditor",
+    "when": "isWindows"
+  },
+  {
+    "key": "ctrl+shift+tab",
+    "command": "workbench.action.previousEditor",
+    "when": "isWindows"
   }
   // Terminal
   // {


### PR DESCRIPTION
## Summary
- add ctrl+tab and ctrl+shift+tab bindings for next/previous editor on Windows
- document the new shortcuts in the keybindings cheat sheet

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_687e54cd4934832dbf6b45569b3716b6