### PR TITLE
Fix tmux alt leader key

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ Automatically switches mode of fn keys per program. Important as keyboard macros
 
 Allows increased brightness when viewing SDR content on an HDR monitor.
 
+## tmux
+
+Using Option as a secondary leader key requires kitty to forward Option as Alt.
+This is configured via `macos_option_as_alt yes` in `~/.config/kitty/kitty.conf`.
+
 # Windows
 
 ## Config

--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -9,6 +9,9 @@ set -g prefix C-b
 set -g prefix2 M-a
 bind-key -n S-F2 send-prefix
 
+# Needed for kitty on macOS so Option sends proper escape sequences
+set -g xterm-keys on
+
 # Reduce delay when using Alt-based keys
 set -s escape-time 0
 


### PR DESCRIPTION
## Summary
- enable xterm-style key sequences in `dot_tmux.conf`
- document Option-as-Alt requirement for kitty in README

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_687edbf0cdb0832d9a413e36b7d1f5b3