### PR TITLE
Enable kitty modifier support in tmux

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -11,6 +11,10 @@ bind-key -n S-F2 send-prefix
 
 # Reduce delay when using Alt-based keys
 set -s escape-time 0
+# Make tmux recognise keys modified with Alt/Meta/Shift
+set-option -g extended-keys on
+# Advertise that xterm-kitty supports extended keys
+set-option -g terminal-features 'xterm-kitty:extkeys'
 
 # Optional: double-tap Ctrl-b to send a literal C-b
 bind-key C-b send-prefix
@@ -22,7 +26,8 @@ bind-key k select-pane -U
 bind-key l select-pane -R
 
 # Ensure we get nice colors
-set -g default-terminal "tmux-256color"
+# Tell tmux that it is running inside kitty
+set -g default-terminal "xterm-kitty"
 
 # Don't eat events that the program should receive (though there is still some issue here)
 unbind -n C-s


### PR DESCRIPTION
## Summary
- handle extended keys from kitty
- set default terminal to `xterm-kitty`

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_687ee7b031c4832d82cb036e99ee7269