### PR TITLE
Disable diagnostic squiggles and whitespace marks

### DIFF
--- a/dot_config/nvim/lua/config/options.lua
+++ b/dot_config/nvim/lua/config/options.lua
@@ -34,3 +34,12 @@ if vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1 or vim.fn.has("win32unix
 end
 
 vim.opt.clipboard:append("unnamedplus")
+
+-- Disable underlined diagnostics (squiggles)
+vim.diagnostic.config({ underline = false })
+
+-- Hide the tabline unless multiple tab pages are open
+vim.opt.showtabline = 0
+
+-- Don't show whitespace characters like tabs by default
+vim.opt.list = false


### PR DESCRIPTION
## Summary
- turn off diagnostic underlines
- hide the tabline unless multiple tab pages exist
- don't display whitespace characters

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`
- `stylua dot_config/nvim/lua/config/options.lua`


------
https://chatgpt.com/codex/tasks/task_e_687edcfa5e40832d9e4aa1b6fdb63bd0