### PR TITLE
Add Shift-F key mappings for kitty and nvim

### DIFF
--- a/dot_config/kitty/kitty.conf
+++ b/dot_config/kitty/kitty.conf
@@ -34,10 +34,6 @@ map cmd+s send_key shift+f5
 map cmd+shift+[ send_key shift+f9
 map cmd+shift+] send_key shift+f10
 
-# Switch tabs with ⌘ + ←/→
-map cmd+shift+] no_op
-map cmd+shift+[ no_op
-
 map cmd+left previous_tab
 map cmd+right next_tab
 

--- a/dot_config/kitty/kitty.conf
+++ b/dot_config/kitty/kitty.conf
@@ -29,6 +29,11 @@ map ctrl+shift+v paste_from_clipboard
 # Normally I would map this to ⌘ + n but hard to press that on Kinesis keyboard
 map cmd+t new_tab
 
+# Map Cmd+S and Cmd+Shift+[] to Shift+Function keys for Neovim
+map cmd+s send_key shift+f5
+map cmd+shift+[ send_key shift+f9
+map cmd+shift+] send_key shift+f10
+
 # Switch tabs with ⌘ + ←/→
 map cmd+shift+] no_op
 map cmd+shift+[ no_op

--- a/dot_config/nvim/lua/config/keymaps.lua
+++ b/dot_config/nvim/lua/config/keymaps.lua
@@ -77,6 +77,9 @@ end, { desc = "Source current file" })
 -- Save file with Ctrl+S in normal and insert mode
 map({ "n", "i" }, "<D-s>", "<cmd>w<CR>", { desc = "Save file" })
 
+-- Same action via Shift+F5 (sent by kitty Cmd+S)
+map_shift_f(5, "<cmd>w<CR>", { mode = { "n", "i" }, desc = "Save file" })
+
 -- Toggle between source and header files (requires clangd)
 map("n", "<A-o>", "<cmd>ClangdSwitchSourceHeader<CR>", { desc = "Switch header/source" })
 
@@ -100,6 +103,10 @@ vim.keymap.del("n", "<S-l>")
 map("n", "<D-S-]>", ":bnext<CR>", { desc = "Next buffer" })
 -- Previous buffer: Cmd+Shift+[
 map("n", "<D-S-[>", ":bprevious<CR>", { desc = "Previous buffer" })
+
+-- Same actions via Shift+F10/F9 (sent by kitty Cmd+Shift+] and [)
+map_shift_f(10, ":bnext<CR>", { desc = "Next buffer" })
+map_shift_f(9, ":bprevious<CR>", { desc = "Previous buffer" })
 
 -- Move tab left/right
 map("n", "<leader>bh", "<cmd>tabmove -1<CR>", { desc = "Move tab left" })


### PR DESCRIPTION
## Summary
- remap kitty Cmd+S/Shift+[ / Shift+] to Shift+Function keys
- wire new Shift+F keybindings in Neovim

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_687f0a7dd618832d8d9f7acd776ab2cb