### PR TITLE
Switch to JetBrains Mono

### DIFF
--- a/darwin/run_once_30-setup.sh.tmpl
+++ b/darwin/run_once_30-setup.sh.tmpl
@@ -40,9 +40,9 @@ if brew list fd >/dev/null 2>&1 && ! brew list --formula | grep -q "^fd$"; then
     brew link --overwrite fd || echo "Failed to link fd, continuing..."
 fi
 
-# Install fonts (macOS-specific: font-fira-code-nerd-font)
+# Install fonts (macOS-specific: font-jetbrains-mono-nerd-font)
 echo "Installing fonts..."
-brew install --cask font-fira-code-nerd-font || echo "Failed to install font-fira-code-nerd-font, continuing..."
+brew install --cask font-jetbrains-mono-nerd-font || echo "Failed to install font-jetbrains-mono-nerd-font, continuing..."
 
 echo "macOS setup complete!"
 

--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -15,9 +15,9 @@
   "security.workspace.trust.untrustedFiles": "prompt",
   // Increase terminal scrollback similar to using a terminal split in Neovim
   "terminal.integrated.scrollback": 10000,
-  "editor.fontFamily": "FiraCode Nerd Font, Fira Code, monospace",
+  "editor.fontFamily": "JetBrainsMono Nerd Font, JetBrains Mono, monospace",
   "editor.fontLigatures": true,
-  "terminal.integrated.fontFamily": "FiraCode Nerd Font, Fira Code, monospace",
+  "terminal.integrated.fontFamily": "JetBrainsMono Nerd Font, JetBrains Mono, monospace",
   "terminal.integrated.defaultProfile.linux": "zsh",
   "terminal.integrated.defaultProfile.osx": "zsh",
   "terminal.integrated.defaultProfile.windows": "pwsh",

--- a/dot_config/kitty/kitty.conf
+++ b/dot_config/kitty/kitty.conf
@@ -8,11 +8,11 @@ padding_width 8
 
 font_size 18.0
 
-# Use FiraCode Nerd Font with ligatures enabled
-font_family FiraCode Nerd Font
-bold_font FiraCode Nerd Font Bold
-italic_font FiraCode Nerd Font Italic
-bold_italic_font FiraCode Nerd Font Bold Italic
+# Use JetBrainsMono Nerd Font with ligatures enabled
+font_family JetBrainsMono Nerd Font
+bold_font JetBrainsMono Nerd Font Bold
+italic_font JetBrainsMono Nerd Font Italic
+bold_italic_font JetBrainsMono Nerd Font Bold Italic
 disable_ligatures never
 
 # Quality of life improvements

--- a/linux/run_once_30-setup.sh.tmpl
+++ b/linux/run_once_30-setup.sh.tmpl
@@ -38,8 +38,8 @@ APT_PACKAGES+=(zsh zsh-autosuggestions zsh-syntax-highlighting)
 echo "Installing: ${APT_PACKAGES[*]}"
 $SUDO apt-get install -y "${APT_PACKAGES[@]}" || true
 
-# Install Fira Code font using apt
-$SUDO apt-get install -y fonts-firacode || true
+# Install JetBrains Mono font using apt
+$SUDO apt-get install -y fonts-jetbrains-mono || true
 
 # Set zsh as the default shell if available
 if command -v zsh >/dev/null 2>&1; then

--- a/windows/run_once_30-setup.ps1.tmpl
+++ b/windows/run_once_30-setup.ps1.tmpl
@@ -41,13 +41,13 @@ if (Get-Command winget -ErrorAction SilentlyContinue) {
 } else {
     Write-Warning "winget is not available. Skipping winget app installs."
 }
-# Install fonts (Windows-specific: FiraCode-NF)
-$fontName = "FiraCode Nerd Font"
-$fontInstalled = (Get-ChildItem -Path "$env:WINDIR\Fonts" -Include "*FiraCode*NF*.ttf" -Recurse -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
+# Install fonts (Windows-specific: JetBrainsMono-NF)
+$fontName = "JetBrainsMono Nerd Font"
+$fontInstalled = (Get-ChildItem -Path "$env:WINDIR\Fonts" -Include "*JetBrainsMono*NF*.ttf" -Recurse -ErrorAction SilentlyContinue | Measure-Object).Count -gt 0
 if (-not $fontInstalled) {
-    Write-Warning "FiraCode-NF font is not installed. Please install it manually from https://github.com/ryanoasis/nerd-fonts/releases."
+    Write-Warning "JetBrainsMono-NF font is not installed. Please install it manually from https://github.com/ryanoasis/nerd-fonts/releases."
 } else {
-    Write-Host "FiraCode-NF font is already installed."
+    Write-Host "JetBrainsMono-NF font is already installed."
 }
 # Ensure LLVM (clang) is in PATH for C compiler support
 $llvmBin = "$env:ProgramFiles\LLVM\bin"


### PR DESCRIPTION
## Summary
- update Kitty terminal to use JetBrains Mono Nerd Font
- use JetBrains Mono in VS Code settings
- install JetBrains Mono font in linux, macOS, and Windows setup scripts

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_687f82744784832d9daaa6df69a1bdff