### PR TITLE
Fix tmux color escape sequences in VSCode

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -35,8 +35,11 @@ bind-key e select-pane -U
 bind-key i select-pane -R
 
 # Ensure we get nice colors
-# Tell tmux that it is running inside kitty
-set -g default-terminal "xterm-kitty"
+# Use kitty terminfo when launching tmux inside kitty, otherwise fall back
+# to a generic tmux-256color entry so other terminals like VSCode work
+if-shell '[ "$TERM" = "xterm-kitty" ]' \
+  'set -g default-terminal "xterm-kitty"' \
+  'set -g default-terminal "tmux-256color"'
 
 # Don't eat events that the program should receive (though there is still some issue here)
 # unbind -n C-s


### PR DESCRIPTION
## Summary
- ensure tmux only uses the `xterm-kitty` terminfo when inside kitty

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_688040e01400832d86ec3f1ede800240