### PR TITLE
Add Ctrl+S passthrough for VS Code terminal

### DIFF
--- a/docs/vscode-keybindings.md
+++ b/docs/vscode-keybindings.md
@@ -19,6 +19,7 @@ This document lists all custom shortcuts defined in [`dot_config/Code/User/keybi
 
 ## Terminal
 - `Ctrl+/` – toggle the integrated terminal.
+- `Ctrl+S` – send Ctrl+S to the integrated terminal when focused.
 
 ## Explorer
 - `Escape` – toggle the sidebar when focus is in the explorer.

--- a/dot_config/Code/User/keybindings.json
+++ b/dot_config/Code/User/keybindings.json
@@ -451,6 +451,12 @@
     "key": "ctrl+shift+tab",
     "command": "workbench.action.previousEditor",
     "when": "isWindows"
+  },
+  {
+    "key": "ctrl+s",
+    "command": "workbench.action.terminal.sendSequence",
+    "args": { "text": "\u0013" },
+    "when": "terminalFocus"
   }
   // Terminal
   // {


### PR DESCRIPTION
## Summary
- send Ctrl+S to the integrated terminal when it has focus
- document the new shortcut

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_6880529ecfd0832daae8fe3b19e1fe51