### PR TITLE
Forward Ctrl+S to integrated terminal

### DIFF
--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -21,6 +21,10 @@
   "terminal.integrated.defaultProfile.linux": "zsh",
   "terminal.integrated.defaultProfile.osx": "zsh",
   "terminal.integrated.defaultProfile.windows": "pwsh",
+  // Forward Ctrl+S to the terminal by removing the save command from the skip list
+  "terminal.integrated.commandsToSkipShell": [
+    "-workbench.action.files.save"
+  ],
   "editor.formatOnSave": true,
   "window.zoomLevel": 0.2,
   // Cursor Shape & Style


### PR DESCRIPTION
## Summary
- allow `Ctrl+S` to reach VS Code's integrated terminal

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_68805bb5e5f4832da7e1e6a2dd6c62ce