### PR TITLE
Configure lazygit to use delta

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The setup scripts also install speedy alternatives for common commands:
 - `bat` as a colorful `cat`
 - `eza` as an improved `ls`
 - `yazi` as a modern terminal file manager
+- `delta` for modern git diffs (also used in Lazygit)
 
 # Mac
 

--- a/dot_config/lazygit/config.yml
+++ b/dot_config/lazygit/config.yml
@@ -1,0 +1,4 @@
+git:
+  paging:
+    colorArg: always
+    pager: delta --paging=never


### PR DESCRIPTION
## Summary
- use delta when lazygit displays diffs
- document delta in the fast CLI tools list

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68806c8dd634832d8aee80db170367de