### PR TITLE
Add macOS lazygit symlink

### DIFF
--- a/Library/Application Support/lazygit/symlink_config.yml.tmpl
+++ b/Library/Application Support/lazygit/symlink_config.yml.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.config/lazygit/config.yml


### PR DESCRIPTION
## Summary
- symlink lazygit config under macOS `Library/Application Support`

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_68806e7d0fb8832dba28fab57aef4e6d