### PR TITLE
Improve VSCode SSH setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,17 @@ I'm using a few plugins:
 Extensions listed in `vscode_extensions.txt` will be installed automatically
 when these dotfiles are applied. Custom keybindings are documented in
 [`docs/vscode-keybindings.md`](docs/vscode-keybindings.md).
+
+For remote development, install the **Remote - SSH** extension. Add your server
+details to `~/.ssh/config`, e.g.
+
+```ssh
+Host devbox
+  HostName server.example.com
+  User you
+```
+
+Use the “Remote-SSH: Connect to Host…” command in VS Code to start a session.
 ```
 
 # Keyboard

--- a/vscode_extensions.txt
+++ b/vscode_extensions.txt
@@ -6,3 +6,4 @@ esbenp.prettier-vscode
 llvm-vs-code-extensions.vscode-clangd
 dautroc.yazi-vscode
 chaitanyashahare.lazygit
+ms-vscode-remote.remote-ssh


### PR DESCRIPTION
## Summary
- document how to connect via Remote-SSH
- install the Remote-SSH VS Code extension by default

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_688107cae6c8832da23a605a45eb2c9f