### PR TITLE
Fix VS Code build hotkeys

### DIFF
--- a/dot_config/Code/User/keybindings.json
+++ b/dot_config/Code/User/keybindings.json
@@ -70,7 +70,7 @@
   // Build
   {
     "key": "shift+f2",
-    "command": "workbench.action.debug.start",
+    "command": "workbench.action.tasks.build",
     "when": "taskCommandsRegistered"
   },
   // Fuzzy find class / file by name
@@ -166,7 +166,13 @@
   // Stop Build / Stop Debugging
   {
     "key": "shift+f7",
-    "command": "workbench.action.debug.stop"
+    "command": "runCommands",
+    "args": {
+      "commands": [
+        "workbench.action.tasks.terminate",
+        "workbench.action.debug.stop"
+      ]
+    }
   },
   // Goto Definition
   {


### PR DESCRIPTION
## Summary
- map Shift+F2 to `workbench.action.tasks.build`
- run `workbench.action.tasks.terminate` before stopping debug on Shift+F7

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_6883c28df7dc832da3993c2fc85105dc