### PR TITLE
Add kitty to auto install

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The setup scripts also install speedy alternatives for common commands:
 - `fd` as a faster `find`
 - `bat` as a colorful `cat`
 - `eza` as an improved `ls`
+- `kitty` as a GPU-accelerated terminal emulator
 - `yazi` as a modern terminal file manager
 - `delta` for modern git diffs (also used in Lazygit)
   - diffs are side-by-side by default, while LazyGit shows inline changes

--- a/common_apps.txt
+++ b/common_apps.txt
@@ -6,6 +6,7 @@ bat
 delta
 eza
 less
+kitty
 llvm
 nvim
 zoxide

--- a/darwin/run_once_30-setup.sh.tmpl
+++ b/darwin/run_once_30-setup.sh.tmpl
@@ -22,7 +22,11 @@ echo "Installing common apps..."
 # Install common apps
 for pkg in "${COMMON_APPS[@]}"; do
     echo "Installing $pkg..."
-    brew install "$pkg" || echo "Failed to install $pkg, continuing..."
+    if [[ "$pkg" == "kitty" ]]; then
+        brew install --cask "$pkg" || echo "Failed to install $pkg, continuing..."
+    else
+        brew install "$pkg" || echo "Failed to install $pkg, continuing..."
+    fi
 done
 
 brew install zsh-autosuggestions zsh-syntax-highlighting

--- a/windows/run_once_30-setup.ps1.tmpl
+++ b/windows/run_once_30-setup.ps1.tmpl
@@ -21,6 +21,7 @@ if (Get-Command winget -ErrorAction SilentlyContinue) {
         'less'     = 'jftuga.less'
         'llvm'     = 'LLVM.LLVM'
         'nvim'     = 'Neovim.Neovim'
+        'kitty'    = 'KovidGoyal.Kitty'
         'starship' = 'Starship.Starship'
         'zoxide'   = 'AjeetDSouza.Zoxide'
         'yazi'     = 'yazi-dev.yazi'


### PR DESCRIPTION
## Summary
- auto-install kitty across all platforms
- install kitty as a Homebrew cask on macOS
- map kitty to KovidGoyal.Kitty for winget
- document kitty among default CLI tools

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_6883c250477c832da39779cc8e2a2ddb