### PR TITLE
Fix CI chezmoi install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,22 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Ensure chezmoi is installed (Unix)
-        if: runner.os != 'Windows'
-        shell: bash
-        run: |
-          if ! command -v chezmoi >/dev/null; then
-            echo "chezmoi not found. Attempting to install via package manager"
-            sudo apt-get update && sudo apt-get install -y chezmoi || brew install chezmoi || {
-              echo "chezmoi is required. Install it manually." && exit 1
-            }
-          fi
+        - name: Ensure chezmoi is installed (Unix)
+          if: runner.os != 'Windows'
+          shell: bash
+          run: |
+            if ! command -v chezmoi >/dev/null; then
+              echo "chezmoi not found. Attempting to install"
+              if command -v apt-get >/dev/null; then
+                sudo apt-get update -y
+                sudo apt-get install -y chezmoi || \
+                  sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
+              elif command -v brew >/dev/null; then
+                brew install chezmoi
+              else
+                sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
+              fi
+            fi
 
       - name: Ensure chezmoi is installed (Windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
## Summary
- robustly install chezmoi in CI workflow using official script if package managers fail

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_6883e457aed0832d9209db2c577661a7