### PR TITLE
Fix VS Code extension install on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ I'm using a few plugins:
 Extensions listed in `vscode_extensions.txt` will be installed automatically
 when these dotfiles are applied. Custom keybindings are documented in
 [`docs/vscode-keybindings.md`](docs/vscode-keybindings.md).
+On macOS, the install script also checks for the default CLI at
+`/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code` if the
+`code` command isn't in your `PATH`.
 
 For remote development, install the **Remote - SSH** extension. Add your server
 details to `~/.ssh/config`, e.g.

--- a/run_once_40-install-vscode-extensions.sh.tmpl
+++ b/run_once_40-install-vscode-extensions.sh.tmpl
@@ -6,6 +6,8 @@ if command -v code >/dev/null 2>&1; then
     CODE_CMD="code"
 elif command -v cursor >/dev/null 2>&1; then
     CODE_CMD="cursor"
+elif [ -f "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" ]; then
+    CODE_CMD="/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
 else
     echo "VS Code 'code' or 'cursor' command not found, skipping extension install"
     exit 0


### PR DESCRIPTION
## Summary
- update VS Code extension install script to fall back to macOS default path
- document the macOS CLI fallback path in README

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`
- `shellcheck run_once_40-install-vscode-extensions.sh.tmpl`


------
https://chatgpt.com/codex/tasks/task_e_6883e4868dd0832da1c5ac9f55f26a2b