### PR TITLE
Fix CI winget install and shellcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
         run: |
           if (-not (Get-Command chezmoi -ErrorAction SilentlyContinue)) {
             Write-Host 'chezmoi not found. Attempting winget install.'
-            winget install twpayne.chezmoi -e --id twpayne.chezmoi `
+            winget install twpayne.chezmoi -e --id twpayne.chezmoi \
+              --accept-package-agreements --accept-source-agreements `
               || throw 'chezmoi is required. Install it manually.'
           }
 
@@ -54,7 +55,7 @@ jobs:
         run: sudo apt-get update -y && sudo apt-get install -y shellcheck stylua
       - name: Shellcheck
         run: |
-          find . -name '*.sh' -print | xargs -r shellcheck
+          find . \( -name '*.sh' -o -name '*.sh.tmpl' -o -name 'dot_*rc' \) -type f -print0 | xargs -0 -r shellcheck
       - name: Stylua
         run: |
-          find dot_config/nvim -name '*.lua' | xargs -r stylua -c
+          find dot_config/nvim -name '*.lua' -type f -print0 | xargs -0 -r stylua -c

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ chezmoi apply
 ### Windows
 
 ```ps
-winget install twpayne.chezmoi
+winget install twpayne.chezmoi --accept-package-agreements --accept-source-agreements
 chezmoi init skyde
 # Review changes if desired
 chezmoi diff

--- a/linux/run_once_30-setup.sh.tmpl
+++ b/linux/run_once_30-setup.sh.tmpl
@@ -54,9 +54,12 @@ fi
 # Final debug check
 echo "=== FINAL DEBUG ==="
 for pkg in "${COMMON_APPS[@]}"; do
-    echo "which $pkg: $(which "$pkg" 2>/dev/null || echo 'not found')"
-    if command -v "$pkg" >/dev/null 2>&1; then
-        echo "$pkg version: $("$pkg" --version 2>/dev/null | head -1 || echo 'version not available')"
+    pkg_path=$(command -v "$pkg" 2>/dev/null || true)
+    if [ -n "$pkg_path" ]; then
+        echo "$pkg is at: $pkg_path"
+        echo "$pkg version: $("$pkg" --version 2>/dev/null | head -n 1 || echo 'version not available')"
+    else
+        echo "$pkg: not found"
     fi
 done
 


### PR DESCRIPTION
## Summary
- auto-accept agreements for Windows winget install
- improve Linux debug step to avoid `which`
- adjust linter commands for shellcheck and stylua
- update README Windows instructions

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`
- `shellcheck linux/run_once_30-setup.sh.tmpl`

------
https://chatgpt.com/codex/tasks/task_e_68840c4b13b0832d88945d0b13311e85