### PR TITLE
Fix typos in VSCode and Vim comments

### DIFF
--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -360,7 +360,7 @@
       "after": ["<C-6>"]
     },
     {
-      // TODO: Ideally <leader>bp is a toggle, but non trival to get this to work
+      // TODO: Ideally <leader>bp is a toggle, but non-trivial to get this to work
       "before": ["<leader>", "b", "u"],
       "commands": ["workbench.action.unpinEditor"],
       "when": "activeEditorIsPinned"

--- a/dot_vsvimrc
+++ b/dot_vsvimrc
@@ -176,7 +176,7 @@ map <leader>sg :vsc Tools.FastFind.OpenDocked<CR>
 
 " Window
 
-" Set fullscreen mode using a plugin called 'Minimal VS Plugin' (the memonic is Window -> Fullscreen)
+" Set fullscreen mode using a plugin called 'Minimal VS Plugin' (the mnemonic is Window -> Fullscreen)
 nnoremap <leader>wf :vsc View.Hidemenu<CR>
 " nnoremap <leader>ws :vsc Window.NewVerticalTabGroup<CR>
 " nnoremap <leader>wv :vsc Window.Split<CR>


### PR DESCRIPTION
## Summary
- fix small typo in `settings.json`
- correct "memonic" to "mnemonic" in `.vsvimrc`

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_6884ef431408832d88e28adbffab6a9c