### PR TITLE
Update terminal close behavior

### DIFF
--- a/dot_config/Code/User/keybindings.json
+++ b/dot_config/Code/User/keybindings.json
@@ -255,13 +255,27 @@
     // If the terminal is focused then close it
     "key": "ctrl+/",
     "when": "terminalFocus",
-    "command": "workbench.action.terminal.toggleTerminal"
+    "command": "runCommands",
+    "args": {
+      "commands": [
+        // Exit terminal full screen before closing
+        "workbench.action.toggleMaximizedPanel",
+        "workbench.action.terminal.toggleTerminal"
+      ]
+    }
   },
   {
     // If the terminal is focused then close it
     "key": "cmd+t",
     "when": "terminalFocus",
-    "command": "workbench.action.terminal.toggleTerminal"
+    "command": "runCommands",
+    "args": {
+      "commands": [
+        // Exit terminal full screen before closing
+        "workbench.action.toggleMaximizedPanel",
+        "workbench.action.terminal.toggleTerminal"
+      ]
+    }
   },
   // File explorer & Git
   {


### PR DESCRIPTION
## Summary
- update VS Code keybindings so closing the terminal exits fullscreen first

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68861b600d24832d86789ae26f7147de