### PR TITLE
Update terminal toggle shortcut

### DIFF
--- a/docs/vscode-keybindings.md
+++ b/docs/vscode-keybindings.md
@@ -20,6 +20,7 @@ This document lists all custom shortcuts defined in [`dot_config/Code/User/keybi
 ## Terminal
 - `Ctrl+/` – toggle the integrated terminal.
 - `Ctrl+S` – send Ctrl+S to the integrated terminal when focused.
+- `Cmd+T` – toggle the terminal visibility and exit fullscreen if needed.
 
 ## Explorer
 - `Escape` – toggle the sidebar when focus is in the explorer.

--- a/dot_config/Code/User/keybindings.json
+++ b/dot_config/Code/User/keybindings.json
@@ -235,10 +235,10 @@
     }
   },
   {
-    // Open the terminal form the editor
+    // Open the terminal from the editor when it's closed
     // Ensure it opens full screen
     "key": "cmd+t",
-    "when": "!terminalFocus",
+    "when": "!terminalIsOpen",
     "command": "runCommands",
     "args": {
       "commands": [
@@ -252,9 +252,9 @@
     }
   },
   {
-    // If the terminal is focused then close it
-    "key": "ctrl+/",
-    "when": "terminalFocus",
+    // Close the maximized terminal even when it's not focused
+    "key": "cmd+t",
+    "when": "terminalIsOpen && !terminalFocus && panelMaximized",
     "command": "runCommands",
     "args": {
       "commands": [
@@ -265,9 +265,15 @@
     }
   },
   {
-    // If the terminal is focused then close it
+    // Close the terminal when it's not focused and not maximized
     "key": "cmd+t",
-    "when": "terminalFocus",
+    "when": "terminalIsOpen && !terminalFocus && !panelMaximized",
+    "command": "workbench.action.terminal.toggleTerminal"
+  },
+  {
+    // If the terminal is focused then close it
+    "key": "ctrl+/",
+    "when": "terminalFocus && panelMaximized",
     "command": "runCommands",
     "args": {
       "commands": [
@@ -276,6 +282,31 @@
         "workbench.action.terminal.toggleTerminal"
       ]
     }
+  },
+  {
+    // If the terminal is focused and not maximized then close it
+    "key": "ctrl+/",
+    "when": "terminalFocus && !panelMaximized",
+    "command": "workbench.action.terminal.toggleTerminal"
+  },
+  {
+    // If the terminal is focused then close it
+    "key": "cmd+t",
+    "when": "terminalFocus && panelMaximized",
+    "command": "runCommands",
+    "args": {
+      "commands": [
+        // Exit terminal full screen before closing
+        "workbench.action.toggleMaximizedPanel",
+        "workbench.action.terminal.toggleTerminal"
+      ]
+    }
+  },
+  {
+    // If the terminal is focused and not maximized then close it
+    "key": "cmd+t",
+    "when": "terminalFocus && !panelMaximized",
+    "command": "workbench.action.terminal.toggleTerminal"
   },
   // File explorer & Git
   {


### PR DESCRIPTION
## Summary
- refine Cmd+T so closing the terminal resets fullscreen only when maximized
- update docs for the new terminal toggle behavior

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68861f30ef10832d9a868e2596b3b078