### PR TITLE
Improve Spotlight command tap logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Activate with footpedal + r. Navigate with arrow keys and space to select.
 
 ## Hammerspoon
 
-Spotlight opens when the Cmd key is tapped by itself.
+Spotlight opens when the Cmd key is quickly tapped by itself. A short delay prevents accidental triggers.
 
 ## Fluor
 

--- a/dot_hammerspoon/init.lua
+++ b/dot_hammerspoon/init.lua
@@ -5,6 +5,8 @@
 local cmdPressed = false
 local otherKeyPressed = false
 local cmdDownTime = 0
+local cmdThreshold = 0.15
+local cmdReleaseDelay = 0.05
 
 local keyDownListener = hs.eventtap.new({ hs.eventtap.event.types.keyDown }, function(_)
     if cmdPressed then
@@ -22,8 +24,13 @@ local flagsListener = hs.eventtap.new({ hs.eventtap.event.types.flagsChanged }, 
         cmdDownTime = hs.timer.secondsSinceEpoch()
     elseif not flags.cmd and cmdPressed then
         cmdPressed = false
-        if not otherKeyPressed and hs.timer.secondsSinceEpoch() - cmdDownTime < 0.2 then
-            hs.eventtap.keyStroke({ "cmd" }, "space", 0)
+        local elapsed = hs.timer.secondsSinceEpoch() - cmdDownTime
+        if not otherKeyPressed and elapsed < cmdThreshold then
+            hs.timer.doAfter(cmdReleaseDelay, function()
+                if not cmdPressed and not otherKeyPressed then
+                    hs.eventtap.keyStroke({ "cmd" }, "space", 0)
+                end
+            end)
         end
     elseif cmdPressed and (flags.alt or flags.shift or flags.ctrl or flags.fn) then
         otherKeyPressed = true


### PR DESCRIPTION
## Summary
- refine Hammerspoon shortcut to avoid accidental triggers
- document quick tap behavior in README

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_688837ad1cf8832da9c215d19c099742