### PR TITLE
Add fuzzy history search

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -88,6 +88,17 @@ if command -v fzf >/dev/null; then
   fi
 fi
 
+# Fuzzy search command history with fzf
+if command -v fzf >/dev/null; then
+  function _fzf_history_search() {
+    local selected
+    selected=$(fc -rl 1 | sed 's/^ *[0-9]* *//' | fzf --tac --no-sort --prompt="History> ") || return
+    print -z "$selected"
+  }
+  zle -N _fzf_history_search
+  bindkey '^R' _fzf_history_search
+fi
+
 # Aliases
 alias z='cd'
 alias grep="grep --color=auto"


### PR DESCRIPTION
## Summary
- add `_fzf_history_search` in `dot_zshrc`
- bind `Ctrl-R` to the new widget

## Testing
- `chezmoi apply --dry-run -S . -v`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_6888402b2484832dbc45d2ea296c7bba