### PR TITLE
Disable cursor blinking in kitty

### DIFF
--- a/dot_config/kitty/kitty.conf
+++ b/dot_config/kitty/kitty.conf
@@ -20,6 +20,7 @@ scrollback_lines 10000
 enable_audio_bell no
 confirm_os_window_close 0
 macos_option_as_alt yes
+cursor_blink_interval 0
 
 # Clipboard shortcuts
 map ctrl+shift+c copy_to_clipboard


### PR DESCRIPTION
## Summary
- stop blinking the text cursor in kitty

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_6888bd111664832d8188459b570a66a9