### PR TITLE
Configure remote SSH extensions

### DIFF
--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -938,5 +938,15 @@
   "find-it-faster.findWithinFiles.fuzzRipgrepQuery": true,
   "git.blame.editorDecoration.enabled": false,
   "github.copilot.nextEditSuggestions.enabled": true,
-  "debug.inlineValues": "on"
+  "debug.inlineValues": "on",
+  "remote.SSH.defaultExtensions": [
+    "vscodevim.vim",
+    "tomrijndorp.find-it-faster",
+    "jeff-hykin.better-cpp-syntax",
+    "ms-vscode.cpptools-themes",
+    "esbenp.prettier-vscode",
+    "llvm-vs-code-extensions.vscode-clangd",
+    "dautroc.yazi-vscode",
+    "chaitanyashahare.lazygit"
+  ]
 }


### PR DESCRIPTION
## Summary
- add `remote.SSH.defaultExtensions` to VS Code settings so remote hosts install common extensions automatically

## Testing
- `chezmoi apply --dry-run -S . -v`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_688ac14b7994832db251661b7203d118