### PR TITLE
Enable VS Code merge editor

### DIFF
--- a/dot_config/git/config
+++ b/dot_config/git/config
@@ -18,7 +18,7 @@
     prompt = false
 
 [mergetool "vscode"]
-    cmd = code --wait $MERGED
+    cmd = code --wait --merge $REMOTE $LOCAL $BASE $MERGED
     trustExitCode = true
 
 [diff]


### PR DESCRIPTION
## Summary
- enable VS Code merge editor by adding `--merge` CLI option

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_688c3f710afc832dbe291367d795480c