### PR TITLE
Configure tokyonight night scheme

### DIFF
--- a/dot_config/nvim/lua/plugins/tokyonight.lua
+++ b/dot_config/nvim/lua/plugins/tokyonight.lua
@@ -1,0 +1,26 @@
+return {
+  {
+    "folke/tokyonight.nvim",
+    lazy = false,
+    priority = 1000,
+    opts = {
+      style = "night",
+      transparent = false,
+      terminal_colors = true,
+      styles = {
+        comments = { italic = true },
+        keywords = { italic = true },
+        functions = {},
+        variables = {},
+      },
+    },
+    config = function(_, opts)
+      require("tokyonight").setup(opts)
+      vim.cmd.colorscheme("tokyonight")
+      vim.api.nvim_set_hl(0, "DiffAdd", { bg = "#203227" })
+      vim.api.nvim_set_hl(0, "DiffDelete", { bg = "#37222c" })
+      vim.api.nvim_set_hl(0, "DiffChange", { bg = "#1d2437" })
+      vim.api.nvim_set_hl(0, "DiffText", { bg = "#1d2437", bold = true })
+    end,
+  },
+}


### PR DESCRIPTION
## Summary
- enable tokyonight.nvim with the **night** style
- adjust `Diff*` highlight groups to match the README screenshot

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_688d2ca04b5c832db354849d98f0e19a