### PR TITLE
Fix nvim reload keymap

### DIFF
--- a/dot_config/nvim/lua/config/keymaps.lua
+++ b/dot_config/nvim/lua/config/keymaps.lua
@@ -73,7 +73,7 @@ end, { desc = "Source current file" })
 -- Reload the entire Neovim configuration and plugins
 vim.keymap.set("n", "<leader>rr", function()
   vim.cmd("source $MYVIMRC")
-  vim.cmd("Lazy reload")
+  vim.cmd("Lazy sync")
 end, { desc = "Reload config" })
 
 --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- avoid `Lazy reload` error by using `Lazy sync`

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_688d33e156d4832db0ee489792d1f416