### PR TITLE
Fix nvim diff colors

### DIFF
--- a/dot_config/nvim/lua/plugins/tokyonight.lua
+++ b/dot_config/nvim/lua/plugins/tokyonight.lua
@@ -17,10 +17,7 @@ return {
     config = function(_, opts)
       require("tokyonight").setup(opts)
       vim.cmd.colorscheme("tokyonight")
-      vim.api.nvim_set_hl(0, "DiffAdd", { bg = "#203227" })
-      vim.api.nvim_set_hl(0, "DiffDelete", { bg = "#37222c" })
-      vim.api.nvim_set_hl(0, "DiffChange", { bg = "#1d2437" })
-      vim.api.nvim_set_hl(0, "DiffText", { bg = "#1d2437", bold = true })
+      -- use colorscheme defaults for diff highlighting
     end,
   },
 }


### PR DESCRIPTION
## Summary
- remove custom diff colors so diff and merge views inherit sane defaults

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`
- `stylua dot_config/nvim/lua/plugins/tokyonight.lua`


------
https://chatgpt.com/codex/tasks/task_e_688d37265f20832da088c00563e053d3