### PR TITLE
Add VSCode merge conflict mappings

### DIFF
--- a/docs/vscode-keybindings.md
+++ b/docs/vscode-keybindings.md
@@ -43,6 +43,13 @@ This document lists all custom shortcuts defined in [`dot_config/Code/User/keybi
 - `Shift+Alt+L` – go to previous conflict.
 - `Alt+L` – go to previous unhandled conflict.
 
+`<leader> c o` – accept current change.
+`<leader> c t` – accept incoming change.
+`<leader> c b` – accept both changes.
+`<leader> c 0` – accept selection.
+`] x` – next conflict.
+`[ x` – previous conflict.
+
 
 ## Vim Extension Mappings
 
@@ -136,6 +143,12 @@ The following shortcuts are configured through the VS Code Vim extension via [`s
 - `Shift+Alt+H` – go to next conflict region.
 - `Alt+L` – go to previous unhandled conflict.
 - `Shift+Alt+L` – go to previous conflict region.
+- `<leader> c o` – accept current change.
+- `<leader> c t` – accept incoming change.
+- `<leader> c b` – accept both changes.
+- `<leader> c 0` – accept selection.
+- `] x` – next conflict.
+- `[ x` – previous conflict.
 - `<leader> t r` – run current test
 - `<leader> t d` – debug current test
 - `<leader> t a` – run all tests

--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -752,6 +752,14 @@
     // re(n)ame – triggers the Explorer rename (same as F2) or, if focus is on
     // the editor tab header, renames the file on disk and updates the buffer.
     { "before": ["<leader>", "g", "n"], "commands": ["renameFile"] }, // [EXPL][EDIT]
+
+    // ── 6. Merge conflict resolution ─────────────────────────────────────────
+    { "before": ["<leader>", "c", "o"], "commands": ["merge-conflict.accept.current"] },
+    { "before": ["<leader>", "c", "t"], "commands": ["merge-conflict.accept.incoming"] },
+    { "before": ["<leader>", "c", "b"], "commands": ["merge-conflict.accept.both"] },
+    { "before": ["<leader>", "c", "0"], "commands": ["merge-conflict.accept.selection"] },
+    { "before": ["]", "x"], "commands": ["merge-conflict.next"] },
+    { "before": ["[", "x"], "commands": ["merge-conflict.previous"] },
     // Testing
     {
       "before": ["<leader>", "t", "r"],


### PR DESCRIPTION
## Summary
- map `<leader>c` conflict commands in VS Code Vim settings
- document the new merge-conflict shortcuts

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_688d3c8346f8832d84c9dcecdfe76b93