### PR TITLE
Fix git merge highlights in Neovim

### DIFF
--- a/dot_config/nvim/lua/plugins/git-conflict.lua
+++ b/dot_config/nvim/lua/plugins/git-conflict.lua
@@ -5,6 +5,12 @@ return {
     config = function()
       require("git-conflict").setup({
         default_mappings = false,
+        -- use diff colors from the colorscheme
+        highlights = {
+          current = "DiffText",
+          incoming = "DiffAdd",
+          ancestor = "DiffChange",
+        },
       })
       local map = vim.keymap.set
       map("n", "<leader>co", "<Plug>(git-conflict-ours)", { desc = "Choose ours" })


### PR DESCRIPTION
## Summary
- tweak git-conflict highlights so merge regions use diff colors

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`
- `stylua dot_config/nvim/lua/plugins/git-conflict.lua`


------
https://chatgpt.com/codex/tasks/task_e_688d65ab06e8832d998dbbed491d31e7