### PR TITLE
feat(nvim): set pure black background

### DIFF
--- a/dot_config/nvim/lua/config/options.lua
+++ b/dot_config/nvim/lua/config/options.lua
@@ -2,6 +2,9 @@
 -- Default options that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/options.lua
 -- Add any additional options here
 
+-- Enable true color support
+vim.opt.termguicolors = true
+
 -- Prevent 'edge hugging'
 vim.o.scrolloff = 8
 

--- a/dot_config/nvim/lua/config/options.lua
+++ b/dot_config/nvim/lua/config/options.lua
@@ -38,11 +38,20 @@ end
 
 vim.opt.clipboard:append("unnamedplus")
 
--- Disable underlined diagnostics (squiggles)
 vim.diagnostic.config({ underline = false })
 
--- Hide the tabline unless multiple tab pages are open
+-- Never show the tabline
 vim.opt.showtabline = 0
+
+-- Do not highlight the current line
+vim.opt.cursorline = false
+
+-- Remove the sign column gutter
+vim.opt.signcolumn = "no"
+
+-- Use a bright orange block cursor with black text
+vim.opt.guicursor =
+  "n-v-c-sm:block-Cursor,i-ci-ve:ver25-Cursor,r-cr:hor20-Cursor,o:hor50-Cursor"
 
 -- Don't show whitespace characters like tabs by default
 vim.opt.list = false

--- a/dot_config/nvim/lua/plugins/disable-indent-guides.lua
+++ b/dot_config/nvim/lua/plugins/disable-indent-guides.lua
@@ -1,0 +1,4 @@
+return {
+  { "lukas-reineke/indent-blankline.nvim", enabled = false },
+  { "echasnovski/mini.indentscope", enabled = false },
+}

--- a/dot_config/nvim/lua/plugins/tokyonight.lua
+++ b/dot_config/nvim/lua/plugins/tokyonight.lua
@@ -16,13 +16,15 @@ return {
       on_colors = function(colors)
         colors.bg = "#000000"
         colors.bg_dark = "#000000"
-        colors.bg_float = "#000000"
+        colors.bg_float = "#0d0d0d"
         colors.bg_highlight = "#111111"
       end,
       on_highlights = function(hl, colors)
         hl.Normal = { bg = colors.bg }
-        hl.NormalFloat = { bg = colors.bg }
-        hl.FloatBorder = { bg = colors.bg, fg = colors.fg_dark }
+        hl.NormalFloat = { bg = colors.bg_float }
+        hl.FloatBorder = { bg = colors.bg_float, fg = colors.fg_dark }
+        hl.Cursor = { fg = "#000000", bg = "#ff8800" }
+        hl.CursorLineNr = { fg = colors.blue }
       end,
     },
     config = function(_, opts)

--- a/dot_config/nvim/lua/plugins/tokyonight.lua
+++ b/dot_config/nvim/lua/plugins/tokyonight.lua
@@ -24,7 +24,7 @@ return {
         hl.NormalFloat = { bg = colors.bg_float }
         hl.FloatBorder = { bg = colors.bg_float, fg = colors.fg_dark }
         hl.Cursor = { fg = "#000000", bg = "#ff8800" }
-        hl.CursorLineNr = { fg = colors.blue }
+        hl.CursorLineNr = { fg = "#569cd6" }
       end,
     },
     config = function(_, opts)

--- a/dot_config/nvim/lua/plugins/tokyonight.lua
+++ b/dot_config/nvim/lua/plugins/tokyonight.lua
@@ -13,6 +13,17 @@ return {
         functions = {},
         variables = {},
       },
+      on_colors = function(colors)
+        colors.bg = "#000000"
+        colors.bg_dark = "#000000"
+        colors.bg_float = "#000000"
+        colors.bg_highlight = "#111111"
+      end,
+      on_highlights = function(hl, colors)
+        hl.Normal = { bg = colors.bg }
+        hl.NormalFloat = { bg = colors.bg }
+        hl.FloatBorder = { bg = colors.bg, fg = colors.fg_dark }
+      end,
     },
     config = function(_, opts)
       require("tokyonight").setup(opts)

--- a/dot_config/nvim/lua/plugins/treesitter-context.lua
+++ b/dot_config/nvim/lua/plugins/treesitter-context.lua
@@ -1,4 +1,3 @@
 return {
-  "nvim-treesitter/nvim-treesitter-context",
-  opts = {},
+  { "nvim-treesitter/nvim-treesitter-context", enabled = false },
 }


### PR DESCRIPTION
## Summary
- enforce true color in Neovim
- use pure black background with tokyonight and tweak floating window borders

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_688d690851e4832db2ee84457a0d1519