### PR TITLE
docs: reorganize keybinding guides

### DIFF
--- a/docs/vim-bindings.md
+++ b/docs/vim-bindings.md
@@ -22,12 +22,6 @@ which is also symlinked for use by the Cursor editor.
 - `<leader><leader>` – ReSharper goto file.
 - `<C-s>` – format document and save (works in all modes).
 
-## File Operations
-- `<leader>fm` – open [Yazi](https://github.com/sxyazi/yazi) in the terminal at the current file.
-- `<leader>fM` – open containing folder.
-- `<leader>r` – open terminal window.
-- `<leader>e` – show Solution Explorer.
-
 ## Navigation and Code
 - `gd` – go to definition.
 - `gp` – peek definition.
@@ -41,32 +35,10 @@ which is also symlinked for use by the Cursor editor.
 - `<leader>cR` – rename file.
 - `<leader>ci` – show parameter info.
 
-## Version Control
-- `<leader>gd` – diff against depot.
-- `<leader>go` – open in P4V.
-- `<leader>gr` – revert if unchanged.
-- `<leader>gR` – revert file.
-- `<leader>ga` – mark for add.
-- `<leader>gD` – mark for delete.
-- `<leader>gh` – file history.
-- `<leader>gt` – timelapse view.
-
-## Merge Conflicts
-- `Alt+K` – accept current change.
-- `Shift+Alt+K` – accept all current changes.
-- `Alt+J` – accept incoming change.
-- `Shift+Alt+J` – accept all incoming changes.
-- `Alt+H` – go to next unhandled conflict.
-- `Shift+Alt+H` – go to next conflict region.
-- `Alt+L` – go to previous unhandled conflict.
-- `Shift+Alt+L` – go to previous conflict region.
-
-## Refactoring and Errors
-- `<leader>ce` – Resharper quick fix.
-- `<leader>.` – quick actions for position.
-- `<leader>ee` – show error list.
-- `<leader>en` – next error.
-- `<leader>ep` – previous error.
+## File Operations
+- `<leader>fm` – open containing folder.
+- `<leader>r` – open terminal window.
+- `<leader>e` – show Solution Explorer.
 
 ## Tabs and Windows
 - `]b` / `[b` – next/previous tab.
@@ -78,6 +50,30 @@ which is also symlinked for use by the Cursor editor.
 - `s` – Peasy Motion two‑char jump.
 - `S` – Peasy Motion jump to tab.
 
+## Version Control
+- `<leader>gd` – diff against depot.
+- `<leader>go` – open in P4V.
+- `<leader>gr` – revert if unchanged.
+- `<leader>gR` – revert file.
+- `<leader>ga` – mark for add.
+- `<leader>gD` – mark for delete.
+- `<leader>gh` – file history.
+- `<leader>gt` – timelapse view.
+
+## Refactoring and Errors
+- `<leader>ce` – Resharper quick fix.
+- `<leader>.` – quick actions for position.
+- `<leader>ee` – show error list.
+- `<leader>en` – next error.
+- `<leader>ep` – previous error.
+
+## Build and Search
+- `<leader>mb` – build solution.
+- `<leader>mc` – cancel build.
+- `<leader>mr` – start debugging.
+- `<leader>ms` – stop debugging.
+- `<leader>sg` – open ReSharper Fast Find.
+
 ## Unit Testing
 - `<leader>tr` – run tests from context.
 - `<leader>td` – debug tests from context.
@@ -86,13 +82,6 @@ which is also symlinked for use by the Cursor editor.
 - `<leader>tt` – open unit test sessions.
 - `<leader>e` – next error in solution.
 - `<leader>E` – previous error in solution.
-
-## Build and Search
-- `<leader>mb` – build solution.
-- `<leader>mc` – cancel build.
-- `<leader>mr` – start debugging.
-- `<leader>ms` – stop debugging.
-- `<leader>sg` – open ReSharper Fast Find.
 
 ## Window Management
 - `<leader>wf` – toggle fullscreen (via Minimal VS Plugin).
@@ -111,6 +100,16 @@ which is also symlinked for use by the Cursor editor.
 - `Alt+H` – step over.
 - `Alt+L` – step into.
 - `Alt+K` – step out.
+
+## Merge Conflicts
+- `Alt+K` – accept current change.
+- `Shift+Alt+K` – accept all current changes.
+- `Alt+J` – accept incoming change.
+- `Shift+Alt+J` – accept all incoming changes.
+- `Alt+H` – go to next unhandled conflict.
+- `Shift+Alt+H` – go to next conflict region.
+- `Alt+L` – go to previous unhandled conflict.
+- `Shift+Alt+L` – go to previous conflict region.
 
 ## Hardware Macro Keys
 These key combinations are implemented via keyboard macros rather than in `dot_vsvimrc`:

--- a/docs/vscode-keybindings.md
+++ b/docs/vscode-keybindings.md
@@ -3,52 +3,43 @@
 This document lists all custom shortcuts defined in [`dot_config/Code/User/keybindings.json`](../dot_config/Code/User/keybindings.json). The same file is symlinked for the Cursor editor.
 
 ## Navigation
+- `Ctrl+Tab` – switch to the next tab (Windows only).
+- `Ctrl+Shift+Tab` – switch to the previous tab (Windows only).
 - `PageDown` – scroll one page down and move the cursor to the top of the viewport (matches Vim behavior).
 - `PageUp` – scroll one page up and move the cursor to the bottom of the viewport (matches Vim behavior).
 - `Shift+F4` – scroll up 16 lines.
 - `Shift+F6` – scroll down 16 lines.
-- `Ctrl+Tab` – switch to the next tab (Windows only).
-- `Ctrl+Shift+Tab` – switch to the previous tab (Windows only).
+
+## Terminal
+- `Ctrl+/` – toggle the integrated terminal.
+- `Cmd+T` – toggle the terminal visibility and exit fullscreen if needed.
+- `Cmd+S` – send Ctrl+S to the integrated terminal when focused.
 
 ## Build and Search
 - `Shift+F2` – run the build task.
 - `Shift+F3` – quick open file or symbol.
-- `Shift+F7` – stop build or debugging.
 - `Shift+F8` – go to definition.
 - `Shift+F11` – toggle comment for the current line.
+- `Shift+F7` – stop build or debugging.
 
-## Terminal
-- `Ctrl+/` – toggle the integrated terminal.
-- `Ctrl+S` – send Ctrl+S to the integrated terminal when focused.
-- `Cmd+T` – toggle the terminal visibility and exit fullscreen if needed.
+## Debugging
+- `Alt+H` – step over.
+- `Alt+L` – step into.
+- `Alt+K` – step out.
 
 ## Explorer
 - `Escape` – toggle the sidebar when focus is in the explorer.
 - `o` – create a new file.
-- `c` – rename the selected file.
 - `Shift+O` – create a new folder.
+- `c` – rename the selected file.
 - `d` – delete the selected file.
 
 ## Copilot Chat
 - `Escape` – close Copilot Chat when focused.
-- `Ctrl+N` – start a new conversation in Copilot Chat when the chat window is open.
 
 ## Merge Conflicts
-- `Alt+K` – accept current change.
-- `Shift+Alt+K` – accept all current changes.
-- `Alt+J` – accept incoming change.
-- `Shift+Alt+J` – accept all incoming changes.
-- `Alt+H` – go to next unhandled conflict.
-- `Shift+Alt+H` – go to next conflict.
-- `Shift+Alt+L` – go to previous conflict.
-- `Alt+L` – go to previous unhandled conflict.
-
-`<leader> c o` – accept current change.
-`<leader> c t` – accept incoming change.
-`<leader> c b` – accept both changes.
-`<leader> c 0` – accept selection.
-`] x` – next conflict.
-`[ x` – previous conflict.
+- `Alt+Down` – go to next unhandled conflict.
+- `Alt+Up` – go to previous unhandled conflict.
 
 
 ## Vim Extension Mappings
@@ -135,20 +126,6 @@ The following shortcuts are configured through the VS Code Vim extension via [`s
 - `<leader> g h` – show commit details
 - `<leader> g l` – open timeline
 - `<leader> g n` – rename file
-- `Alt+K` – accept current change during merge.
-- `Shift+Alt+K` – accept all current changes.
-- `Alt+J` – accept incoming change.
-- `Shift+Alt+J` – accept all incoming changes.
-- `Alt+H` – go to next unhandled conflict.
-- `Shift+Alt+H` – go to next conflict region.
-- `Alt+L` – go to previous unhandled conflict.
-- `Shift+Alt+L` – go to previous conflict region.
-- `<leader> c o` – accept current change.
-- `<leader> c t` – accept incoming change.
-- `<leader> c b` – accept both changes.
-- `<leader> c 0` – accept selection.
-- `] x` – next conflict.
-- `[ x` – previous conflict.
 - `<leader> t r` – run current test
 - `<leader> t d` – debug current test
 - `<leader> t a` – run all tests
@@ -161,9 +138,6 @@ The following shortcuts are configured through the VS Code Vim extension via [`s
 - `<leader> m r` – start debugging
 - `<leader> m s` – stop debugging
 - `<leader> d g` – set next statement
-- `Alt+H` – step over.
-- `Alt+L` – step into.
-- `Alt+K` – step out.
 ### Insert Mode
 
 - `<Esc>` – <Esc> <C-g>u


### PR DESCRIPTION
## Summary
- Prioritize frequently used VSVim mappings and fix `<leader>fm` to open the containing folder.
- Reorder VS Code keybindings by importance, clarify terminal shortcuts, add dedicated debugging section, and trim unused merge-conflict mappings.

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_688d863249f0832d8c5d7d685b01d72d