### PR TITLE
chore: tidy keybinding docs and configs

### DIFF
--- a/docs/vscode-keybindings.md
+++ b/docs/vscode-keybindings.md
@@ -23,9 +23,9 @@ This document lists all custom shortcuts defined in [`dot_config/Code/User/keybi
 - `Shift+F7` – stop build or debugging.
 
 ## Debugging
-- `Alt+H` – step over.
-- `Alt+L` – step into.
-- `Alt+K` – step out.
+- `Alt+Down` – step over.
+- `Alt+Up` – step into.
+- `Alt+H` – step out.
 
 ## Explorer
 - `Escape` – toggle the sidebar when focus is in the explorer.
@@ -35,7 +35,7 @@ This document lists all custom shortcuts defined in [`dot_config/Code/User/keybi
 - `d` – delete the selected file.
 
 ## Copilot Chat
-- `Escape` – close Copilot Chat when focused.
+- `Escape` – focus the editor when Copilot Chat is active.
 
 ## Merge Conflicts
 - `Alt+Down` – go to next unhandled conflict.

--- a/dot_config/Code/User/keybindings.json
+++ b/dot_config/Code/User/keybindings.json
@@ -216,7 +216,6 @@
       ]
     }
   },
-  // Terminal
   {
     "key": "cmd+t",
     "command": "workbench.action.closePanel",
@@ -312,16 +311,6 @@
     "key": "escape",
     "when": "sideBarVisible && !editorFocus"
   },
-  // {
-  //   "key": "ctrl+l",
-  //   "command": "diffEditor.switchSide",
-  //   "when": "isInDiffEditor"
-  // },
-  // {
-  //   "key": "ctrl+h",
-  //   "command": "diffEditor.switchSide",
-  //   "when": "isInDiffEditor"
-  // },
   // Copilot Chat
   {
     // Focus back to the editor
@@ -329,12 +318,6 @@
     "command": "workbench.action.focusActiveEditorGroup",
     "when": "view.workbench.panel.chat.view.copilot.visible && !editorFocus"
   },
-  // // Git
-  // {
-  //   "command": "workbench.action.toggleSidebarVisibility",
-  //   "key": "escape",
-  //   "when": "explorerViewletVisible && !inputFocus"
-  // },
   // Explorer
   {
     "key": "o",
@@ -369,44 +352,8 @@
     "command": "workbench.action.compareEditor.previousChange",
     "when": "textCompareEditorVisible && editorTextFocus"
   },
-  // {
-  //   // Revert the selected hunk
-  //   "key": "alt+k",
-  //   "command": "git.revertSelectedRanges",
-  //   "when": "isInDiffEditor && !isInDiffLeftEditor && editorTextFocus"
-  // },
-  // {
-  //   // Stage the selected hunk
-  //   "key": "ctrl+j",
-  //   "command": "git.stageSelectedRanges",
-  //   "when": "isInDiffEditor && !isInDiffLeftEditor && editorTextFocus"
-  // },
-  // {
-  //   // Unstage the selected hunk - this is not working for some reason but maybe would in some context
-  //   "key": "ctrl+alt+j",
-  //   "command": "git.unstageSelectedRanges",
-  //   "when": "isInDiffEditor && !isInDiffLeftEditor && editorTextFocus"
-  // },
 
-  // {
-  //   // Fallback revert
-  //   "key": "alt+shift+k",
-  //   "command": "diffEditor.revert",
-  //   "when": "isInDiffEditor && editorTextFocus"
-  // },
 
-  // {
-  //   // Pop up an in place 'peek' of the next diff in any file you are editing
-  //   "key": "alt+l",
-  //   "command": "editor.action.dirtydiff.previous",
-  //   "when": "editorTextFocus && !isInDiffEditor"
-  // },
-  // {
-  //   // Pop up an in place 'peek' of the previous diff in any file you are editing
-  //   "key": "alt+h",
-  //   "command": "editor.action.dirtydiff.next",
-  //   "when": "editorTextFocus && !isInDiffEditor"
-  // },
   // Merging
   {
     "key": "alt+down",
@@ -418,16 +365,6 @@
     "command": "merge.goToPreviousUnhandledConflict",
     "when": "isMergeEditor"
   },
-  // {
-  //   "key": "alt+k",
-  //   "command": "merge.toggleActiveConflictInput1",
-  //   "when": "isMergeEditor"
-  // },
-  // {
-  //   "key": "alt+j",
-  //   "command": "merge.toggleActiveConflictInput2",
-  //   "when": "isMergeEditor"
-  // },
   // Debug Navigation
   {
     "key": "alt+down",
@@ -467,60 +404,4 @@
     "args": { "text": "\u001B[15;2~" }, // sends Shift‑F5
     "when": "terminalFocus"
   }
-  // Terminal
-  // {
-  //   // There is an issue with the find it faster plugin where it does not focus your last editor when you press q, so this fixes that
-  //   "key": "q",
-  //   "command": "runCommands",
-  //   // This only activates when the 'editor as a tab' mode is active. Would be better to use a context set by the find it faster plugin
-  //   "when": "terminalFocus && terminalEditorActive",
-  //   "args": {
-  //     "commands": [
-  //       {
-  //         "command": "workbench.action.terminal.sendSequence",
-  //         // Escape keycode
-  //         "args": { "text": "\u001b" }
-  //       },
-  //       "workbench.action.closeActiveEditor",
-  //       "extension.vim_escape"
-  //     ]
-  //   }
-  // }
-  // {
-  //   // There is an issue with the find it faster plugin where it does not focus your last editor when you press escape, so this fixes that
-  //   "key": "escape",
-  //   "command": "runCommands",
-  //   // This only activates when the 'editor as a tab' mode is active. Would be better to use a context set by the find it faster plugin
-  //   "when": "terminalFocus && terminalEditorActive",
-  //   "args": {
-  //     "commands": [
-  //       {
-  //         "command": "workbench.action.terminal.sendSequence",
-  //         // Escape keycode
-  //         "args": { "text": "\u001b" }
-  //       },
-  //       "workbench.action.closeActiveEditor",
-  //       "extension.vim_escape"
-  //     ]
-  //   }
-  // }
-  // {
-  //   // There is an issue in the find it faster plugin where it does not clear your last selection when you do a search, so this fixes that
-  //   "key": "enter",
-  //   "command": "runCommands",
-  //   // This only activates when the 'editor as a tab' mode is active. Would be better to use a context set by the find it faster plugin
-  //   "when": "terminalFocus && terminalEditorActive",
-  //   "args": {
-  //     "commands": [
-  //       {
-  //         "command": "workbench.action.terminal.sendSequence",
-  //         // Enter keycode
-  //         "args": { "text": "\u000D" }
-  //       },
-  //       "workbench.action.focusActiveEditorGroup",
-  //       "workbench.action.navigateBack",
-  //       "extension.vim_escape"
-  //     ]
-  //   }
-  // }
 ]

--- a/dot_vsvimrc
+++ b/dot_vsvimrc
@@ -148,8 +148,6 @@ nmap s gS:vsc Tools.InvokePeasyMotionTwoCharJump<CR>
 nmap S gS:vsc Tools.InvokePeasyMotionJumpToDocumentTab<CR>
 
 " Resharper
-" noremap ] :vsc ReSharper.ReSharper_GotoNextMember<CR>
-" noremap [ :vsc ReSharper.ReSharper_GotoPrevMember<CR>
 
 map <leader>tr :vsc ReSharper.ReSharper_UnitTestRunFromContext<CR>
 map <leader>td :vsc ReSharper.ReSharper_UnitTestDebugContext<CR>
@@ -167,7 +165,6 @@ map <leader>mr :vsc Debug.Start<CR>
 map <leader>ms :vsc Debug.StopDebugging<CR>
 
 " TODO: Add a macro which does this. replace ms with the macro and remove mc
-" map <leader>mt :vsc Build.Cancel<CR>:vsc Debug.StopDebugging<CR>
 
 " Fuzzy Find
 
@@ -178,9 +175,6 @@ map <leader>sg :vsc Tools.FastFind.OpenDocked<CR>
 
 " Set fullscreen mode using a plugin called 'Minimal VS Plugin' (the mnemonic is Window -> Fullscreen)
 nnoremap <leader>wf :vsc View.Hidemenu<CR>
-" nnoremap <leader>ws :vsc Window.NewVerticalTabGroup<CR>
-" nnoremap <leader>wv :vsc Window.Split<CR>
-" nnoremap <leader>wr :vsc Window.RemoveSplit<CR>
 
 noremap <leader>wp :vsc Window.PinTab<CR>
 noremap <leader>wP :vsc Window.CloseAllButPinned<CR>


### PR DESCRIPTION
## Summary
- document correct VS Code debug keys and Copilot escape behavior【F:docs/vscode-keybindings.md†L25-L28】【F:docs/vscode-keybindings.md†L37-L38】
- drop commented-out keybindings from VS Code and VSVim configs【F:dot_config/Code/User/keybindings.json†L368-L383】【F:dot_vsvimrc†L174-L180】

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_688d8aedbb34832d8aa10ecbe2748a51