### PR TITLE
feat(nvim): disable indent guides

### DIFF
--- a/dot_config/nvim/lua/plugins/disable-indent-guides.lua
+++ b/dot_config/nvim/lua/plugins/disable-indent-guides.lua
@@ -1,4 +1,8 @@
 return {
-  { "lukas-reineke/indent-blankline.nvim", enabled = false },
+  {
+    "lukas-reineke/indent-blankline.nvim",
+    main = "ibl",
+    opts = { enabled = false },
+  },
   { "echasnovski/mini.indentscope", enabled = false },
 }


### PR DESCRIPTION
## Summary
- disable indent-blankline (ibl) and mini.indentscope to remove indent guides

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_688d9d3b8b78832d8440aa86299b70be