### PR TITLE
feat(nvim): hollow insert cursor

### DIFF
--- a/dot_config/nvim/lua/config/options.lua
+++ b/dot_config/nvim/lua/config/options.lua
@@ -49,9 +49,9 @@ vim.opt.cursorline = false
 -- Remove the sign column gutter
 vim.opt.signcolumn = "no"
 
--- Use a bright orange block cursor with black text
+-- Use a bright orange block cursor in normal mode and a hollow block when inserting
 vim.opt.guicursor =
-  "n-v-c-sm:block-Cursor,i-ci-ve:ver25-Cursor,r-cr:hor20-Cursor,o:hor50-Cursor"
+  "n-v-c-sm:block-Cursor,i-ci-ve:block-CursorInsert,r-cr:hor20-Cursor,o:hor50-Cursor"
 
 -- Don't show whitespace characters like tabs by default
 vim.opt.list = false

--- a/dot_config/nvim/lua/plugins/tokyonight.lua
+++ b/dot_config/nvim/lua/plugins/tokyonight.lua
@@ -24,6 +24,7 @@ return {
         hl.NormalFloat = { bg = colors.bg_float }
         hl.FloatBorder = { bg = colors.bg_float, fg = colors.fg_dark }
         hl.Cursor = { fg = "#000000", bg = "#ff8800" }
+        hl.CursorInsert = { fg = "#ff8800", bg = "NONE" }
         hl.CursorLineNr = { fg = "#569cd6" }
       end,
     },


### PR DESCRIPTION
## Summary
- show hollow block cursor in Neovim insert mode

## Testing
- `chezmoi apply --dry-run -S . --verbose`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_688d9e047ff0832d912503008d4115bd