### PR TITLE
chore: darken background highlights

### DIFF
--- a/dot_config/nvim/lua/plugins/tokyonight.lua
+++ b/dot_config/nvim/lua/plugins/tokyonight.lua
@@ -18,6 +18,11 @@ return {
         colors.bg_dark = "#000000"
         colors.bg_float = "#0d0d0d"
         colors.bg_highlight = "#111111"
+        colors.bg_popup = "#0d0d0d"
+        colors.bg_search = "#222222"
+        colors.bg_sidebar = "#000000"
+        colors.bg_statusline = "#111111"
+        colors.bg_visual = "#222222"
       end,
       on_highlights = function(hl, colors)
         hl.Normal = { bg = colors.bg }
@@ -25,6 +30,14 @@ return {
         hl.FloatBorder = { bg = colors.bg_float, fg = colors.fg_dark }
         hl.Cursor = { fg = "#000000", bg = "#ff8800" }
         hl.CursorLineNr = { fg = "#569cd6" }
+        hl.CursorLine = { bg = colors.bg_highlight }
+        hl.Visual = { bg = colors.bg_visual }
+        hl.Search = { bg = colors.bg_search, fg = colors.fg }
+        hl.IncSearch = { bg = colors.bg_search, fg = colors.fg }
+        hl.Pmenu = { bg = colors.bg_popup, fg = colors.fg }
+        hl.PmenuSel = { bg = colors.bg_visual, fg = colors.fg }
+        hl.StatusLine = { bg = colors.bg_statusline, fg = colors.fg }
+        hl.StatusLineNC = { bg = colors.bg_statusline, fg = colors.fg_dark }
       end,
     },
     config = function(_, opts)


### PR DESCRIPTION
## Summary
- ensure plugin highlights match a pure black background

## Testing
- `chezmoi apply --dry-run -S . && echo OK`
- `chezmoi doctor -S .`
- `stylua dot_config/nvim/lua/plugins/tokyonight.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688df71cb5b8832dbc159bec028bbd1a