### PR TITLE
Disable line move shortcuts in VS Code

### DIFF
--- a/docs/vscode-keybindings.md
+++ b/docs/vscode-keybindings.md
@@ -10,6 +10,10 @@ This document lists all custom shortcuts defined in [`dot_config/Code/User/keybi
 - `Shift+F4` – scroll up 16 lines.
 - `Shift+F6` – scroll down 16 lines.
 
+## Editing
+- `Alt+Up` – disabled to prevent moving the current line.
+- `Alt+Down` – disabled to prevent moving the current line.
+
 ## Terminal
 - `Ctrl+/` – toggle the integrated terminal.
 - `Cmd+T` – toggle the terminal visibility and exit fullscreen if needed.

--- a/dot_config/Code/User/keybindings.json
+++ b/dot_config/Code/User/keybindings.json
@@ -1,5 +1,9 @@
 // Place your key bindings in this file to override the defaults
 [
+  // Disable line move shortcuts
+  { "key": "alt+down", "command": "-editor.action.moveLinesDownAction" },
+  { "key": "alt+up", "command": "-editor.action.moveLinesUpAction" },
+
   // Page Down - workround to make cursor movement match Nvim
   {
     "key": "pagedown",


### PR DESCRIPTION
## Summary
- disable Alt+Up/Alt+Down line move defaults in VS Code
- document disabled keybindings

## Testing
- `chezmoi apply --dry-run -S . -v | head -n 20`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_688e2faca81c832dbb93ceb4a82d8cd2