### PR TITLE
Enable fast vim bindings in zsh

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -34,7 +34,8 @@ SAVEHIST=50000
 HISTFILE=~/.zsh_history
 
 # Key Bindings
-bindkey -e                # Use emacs keybindings
+bindkey -v                # Use vim keybindings
+KEYTIMEOUT=1              # Reduce delay for ESC
 bindkey '^[[1;5C' forward-word     # Ctrl+Right
 bindkey '^[[1;5D' backward-word    # Ctrl+Left
 


### PR DESCRIPTION
## Summary
- use vim keybindings in zsh
- reduce ESC key timeout for responsiveness

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`
- `shellcheck dot_zshrc` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ed47b346c832db1e81472c589e4a7