### PR TITLE
feat: bind _ to line start in zsh

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -36,6 +36,7 @@ HISTFILE=~/.zsh_history
 # Key Bindings
 bindkey -v                # Use vim keybindings
 KEYTIMEOUT=1              # Reduce delay for ESC
+bindkey -M vicmd '_' vi-beginning-of-line  # '_' moves to start of line in normal mode
 
 # bindkey -e                # Use emacs keybindings
 # bindkey '^[[1;5C' forward-word     # Ctrl+Right


### PR DESCRIPTION
## Summary
- bind `_` in zsh vi-mode to move cursor to start of line

## Testing
- `shellcheck dot_zshrc` *(fails: command not found)*
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_688ee6a6b28c832d9c70857f6d9ced36