### PR TITLE
Map Y to yank-to-end in VS Code Vim

### DIFF
--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -250,6 +250,10 @@
       "before": ["<C-r>"],
       "commands": [{ "command": "redo" }]
     },
+    {
+      "before": ["Y"],
+      "after": ["y", "$"]
+    },
     // Fuzzy Find
     {
       "before": ["<leader>", "<leader>"],


### PR DESCRIPTION
## Summary
- Remap `Y` in VS Code's Vim extension to yank to end of line

## Testing
- `chezmoi apply --dry-run -S . --verbose`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_688eea86d9d0832dae067181d2e2cad3