### PR TITLE
Add VS Code task and keybinding for fzf content search

### DIFF
--- a/AppData/Roaming/Code/User/symlink_tasks.json.tmpl
+++ b/AppData/Roaming/Code/User/symlink_tasks.json.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.config/Code/User/tasks.json

--- a/Library/Application Support/Code/User/symlink_tasks.json.tmpl
+++ b/Library/Application Support/Code/User/symlink_tasks.json.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.config/Code/User/tasks.json

--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -446,28 +446,14 @@
       "before": ["<leader>", "s", "f"],
       "commands": ["fzf-picker.findFiles"]
     },
-    // {
-    //   // Custom fzf implementation without a plugin - can switch to this if it works
-    //   "before": ["<leader>", "s", "c"],
-    //   "commands": [
-    //     // 1. Open an external (panel) terminal first…
-    //     "workbench.action.terminal.new",
-
-    //     // 2. …send the fzf pipeline + ⏎
-    //     {
-    //       "command": "workbench.action.terminal.sendSequence",
-    //       "args": {
-    //         // "text": "fzf --prompt='rg> ' --bind \\\"change:reload:rg --column --line-number --no-heading --hidden --smart-case {q} || true\\\" --delimiter ':' --preview 'bat --style=numbers --color=always --line-range {2}-5:{2}+5 {1}' --bind \\\"enter:execute(code -g {1}:{2}:{3} > /dev/null)+abort\\\"\\u000D"
-    //         "text": "fzf --prompt='rg'\u000D"
-    //       }
-    //     },
-
-    //     // 3 & 4. Dock the terminal in the editor and hide it
-    //     "workbench.action.terminal.moveToEditor",
-    //     "workbench.action.terminal.toggleTerminal",
-    //     "workbench.action.terminal.toggleTerminal"
-    //   ]
-    // },
+    {
+      // Search file contents using FZF via VS Code task
+      "before": ["<leader>", "s", "c"],
+      "commands": [
+        "workbench.action.tasks.runTask?fzfSearchContent",
+        "workbench.action.terminal.toggleTerminal"
+      ]
+    },
     {
       // Start a new search within files
       "before": ["<leader>", "s", "s"],

--- a/dot_config/Code/User/tasks.json
+++ b/dot_config/Code/User/tasks.json
@@ -1,0 +1,17 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "fzfSearchContent",
+      "type": "shell",
+      "command": "fzf --prompt='rg> ' --bind \"change:reload:rg --column --line-number --no-heading --hidden --smart-case {q} || true\" --delimiter ':' --preview 'bat --style=numbers --color=always --line-range {2}-5:{2}+5 {1}' --bind \"enter:execute(code --reuse-window -g {1}:{2}:{3} > /dev/null)+abort\"",
+      "presentation": {
+        "echo": false,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add VS Code `fzfSearchContent` shell task and symlink templates
- map `<leader>sc` to run the task and hide the terminal in VS Code Neovim

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68900c1c6314832daa2dc7766cf0cec6