### PR TITLE
chore: replace find-it-faster with fzf-picker

### DIFF
--- a/dot_config/Code/User/keybindings.json
+++ b/dot_config/Code/User/keybindings.json
@@ -215,7 +215,7 @@
       "commands": [
         // Automatically search for the word under the cursor
         "editor.action.addSelectionToNextFindMatch",
-        "find-it-faster.findWithinFiles",
+        "fzf-picker.findWithinFiles",
         "extension.vim_escape"
       ]
     }

--- a/vscode_extensions.txt
+++ b/vscode_extensions.txt
@@ -1,5 +1,5 @@
 vscodevim.vim
-tomrijndorp.find-it-faster
+jellydn.fzf-picker
 jeff-hykin.better-cpp-syntax
 ms-vscode.cpptools-themes
 esbenp.prettier-vscode


### PR DESCRIPTION
## Summary
- switch VS Code config from `tomrijndorp.find-it-faster` to `jellydn.fzf-picker` and update keybinding accordingly

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_689009252be4832dae8ba5cbeea38d0b