### PR TITLE
feat(lazygit): enable full page scrolling

### DIFF
--- a/dot_config/lazygit/config.yml
+++ b/dot_config/lazygit/config.yml
@@ -7,6 +7,9 @@ git:
 promptToReturnFromSubprocess: false
 promptToOpenMergeTool: false
 
+gui:
+  scrollHeight: 0
+
 keybinding:
   universal:
     undo: u


### PR DESCRIPTION
## Summary
- allow PageDown to scroll through a full page in lazygit

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68902fc60b10832d9267cd877b0a7436