### PR TITLE
Disable LazyVim spelling autocmd

### DIFF
--- a/dot_config/nvim/lua/config/autocmds.lua
+++ b/dot_config/nvim/lua/config/autocmds.lua
@@ -13,3 +13,5 @@ vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
     vim.bo.filetype = "json"
   end,
 })
+
+vim.api.nvim_del_augroup_by_name("lazyvim_wrap_spell")


### PR DESCRIPTION
## Summary
- disable default LazyVim spell-check autocmd to remove spelling squiggles

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_6890aadd1fac832dbff3d25ba5b3162e