### PR TITLE
Poll Hammerspoon listener periodically

### DIFF
--- a/dot_hammerspoon/init.lua
+++ b/dot_hammerspoon/init.lua
@@ -88,5 +88,8 @@ hs.caffeinate.watcher.new(function(event)
     end
 end):start()
 
+-- Periodically refresh listeners to reduce reliance on system events
+hs.timer.doEvery(5, updateListeners)
+
 -- Activate listeners if an external keyboard is already connected
 updateListeners()


### PR DESCRIPTION
## Summary
- periodically refresh Hammerspoon keyboard listener to avoid relying on wake events

## Testing
- `chezmoi apply --dry-run -S . && echo 'apply ok'`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_688f576cdaec832d95c629dbebfcade6