### PR TITLE
feat(yazi): add shortcut to chezmoi directory

### DIFF
--- a/dot_config/yazi/keymap.toml
+++ b/dot_config/yazi/keymap.toml
@@ -48,5 +48,6 @@ prepend_keymap = [
   { on = [ "9" ], run = "plugin relative-line-numbers 9", desc = "Jump (starts with 9)" },
 
   # Optional helper key – lets you type e.g. “m 4 2 j”
-  { on = [ "m" ], run = "plugin relative-line-numbers", desc = "Start relative jump" }
+  { on = [ "m" ], run = "plugin relative-line-numbers", desc = "Start relative jump" },
+  { on = [ "g", "m" ], run = "cd ~/.local/share/chezmoi", desc = "Go to chezmoi directory" }
 ]


### PR DESCRIPTION
## Summary
- add `gm` keymap in Yazi to quickly open the chezmoi source directory

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68910088f584832db27dbaf39b99bcfb