### PR TITLE
Map <leader>bn to open new tab

### DIFF
--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -314,6 +314,11 @@
     },
     // Buffers
     {
+      // New tab
+      "before": ["<leader>", "b", "n"],
+      "commands": ["workbench.action.files.newUntitledFile"]
+    },
+    {
       // Next tab
       "before": ["]", "b"],
       "commands": ["workbench.action.nextEditor"]

--- a/dot_config/nvim/lua/config/keymaps.lua
+++ b/dot_config/nvim/lua/config/keymaps.lua
@@ -114,6 +114,9 @@ map("n", "<D-S-[>", ":bprevious<CR>", { desc = "Previous buffer" })
 map_shift_f(1, ":bprevious<CR>", { desc = "Previous buffer" })
 map_shift_f(12, ":bnext<CR>", { desc = "Next buffer" })
 
+-- Open new tab
+map("n", "<leader>bn", "<cmd>tabnew<CR>", { desc = "New tab" })
+
 -- Move tab left/right
 map("n", "<leader>bh", "<cmd>tabmove -1<CR>", { desc = "Move tab left" })
 map("n", "<leader>bl", "<cmd>tabmove +1<CR>", { desc = "Move tab right" })


### PR DESCRIPTION
## Summary
- map `<leader>bn` in VS Code to open a new untitled tab
- map `<leader>bn` in Neovim to `:tabnew`

## Testing
- `stylua dot_config/nvim/lua/config/keymaps.lua`
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_6890e71d9544832da65504eccd8abef8