### PR TITLE
feat: sort yazi by modified time

### DIFF
--- a/dot_config/yazi/yazi.toml
+++ b/dot_config/yazi/yazi.toml
@@ -4,6 +4,8 @@
 [mgr]
 ratio = [1, 4, 7]
 show_hidden = true
+sort_by = "modified"
+sort_reverse = true
 
 # [[plugin.prepend_fetchers]]
 # id = "git"


### PR DESCRIPTION
## Summary
- make Yazi list files by modified time in reverse order by default

## Testing
- `chezmoi apply --dry-run -S . --verbose | tail -n 20`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68910da61978832d9847370f4e8a79c7