### PR TITLE
docs: fix typos and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ Use this since it's nicer than the default one.
 
 Ensure you set the correct environment variable to allow the diff to work:
 
-````
+```
 P4DIFF="C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\devenv.exe" /Diff %1 %2
+```
 
 # Visual Studio Code
 
@@ -139,11 +140,9 @@ details to `~/.ssh/config`, e.g.
 Host devbox
   HostName server.example.com
   User you
-````
+```
 
 Use the “Remote-SSH: Connect to Host…” command in VS Code to start a session.
-
-```
 
 # Keyboard
 
@@ -188,4 +187,3 @@ The pedal config:
 The method to open V-Drive is either:
 - Flip the switch on the bottom of the pedal
 - Hold the pedal down briefly while connecting to the computer (waterproof version)
-```

--- a/docs/vim-bindings.md
+++ b/docs/vim-bindings.md
@@ -61,7 +61,7 @@ which is also symlinked for use by the Cursor editor.
 - `<leader>gt` – timelapse view.
 
 ## Refactoring and Errors
-- `<leader>ce` – Resharper quick fix.
+- `<leader>ce` – ReSharper quick fix.
 - `<leader>.` – quick actions for position.
 - `<leader>ee` – show error list.
 - `<leader>en` – next error.

--- a/docs/vscode-keybindings.md
+++ b/docs/vscode-keybindings.md
@@ -86,13 +86,13 @@ The following shortcuts are configured through the VS Code Vim extension via [`s
 - `<S-l>` – :bnext
 - `<leader> w f` – toggle Zen mode
 - `<leader> w F` – toggle fullscreen
-- `leader w v` – :vsplit
-- `leader w s` – :split
-- `leader w d` – close tab
-- `leader w h` – focus left pane
-- `leader w j` – focus pane below
-- `leader w k` – focus pane above
-- `leader w l` – focus right pane
+- `<leader> w v` – :vsplit
+- `<leader> w s` – :split
+- `<leader> w d` – close tab
+- `<leader> w h` – focus left pane
+- `<leader> w j` – focus pane below
+- `<leader> w k` – focus pane above
+- `<leader> w l` – focus right pane
 - `<leader> s g` – search within files
 - `<leader> s f` – search files
 - `<leader> s t` – search files by type
@@ -124,7 +124,6 @@ The following shortcuts are configured through the VS Code Vim extension via [`s
 - `<leader> g d` – view file diff
 - `<leader> g s` – stage changes
 - `<leader> g u` – unstage changes
-- `<leader> g d` – view file diff
 - `<leader> g w` – open file in repo
 - `<leader> g r` – revert selected ranges
 - `<leader> g h` – show commit details


### PR DESCRIPTION
## Summary
- fix ReSharper spelling and other typos
- tidy VS Code keybinding docs and remove duplicate mapping
- clean up README code blocks

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68910d49d3b4832db003b11733f7ce9e