### PR TITLE
Fix Stylua and Windows chezmoi installs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+
 on:
   push:
   pull_request:
@@ -11,7 +12,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Ensure chezmoi is installed (Unix)
         if: runner.os != 'Windows'
@@ -35,9 +36,7 @@ jobs:
         shell: pwsh
         run: |
           if (-not (Get-Command chezmoi -ErrorAction SilentlyContinue)) {
-            Write-Host 'chezmoi not found. Attempting winget install.'
-            winget install twpayne.chezmoi -e --id twpayne.chezmoi `
-              || throw 'chezmoi is required. Install it manually.'
+            choco install -y chezmoi
           }
 
       - name: Dry-run apply
@@ -49,12 +48,21 @@ jobs:
   linters:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Install tools
-        run: sudo apt-get update -y && sudo apt-get install -y shellcheck stylua
+      - uses: actions/checkout@v4
+
+      - name: Install ShellCheck
+        run: sudo apt-get update -y && sudo apt-get install -y shellcheck
+
       - name: Shellcheck
         run: |
           find . -name '*.sh' -print | xargs -r shellcheck
-      - name: Stylua
-        run: |
-          find dot_config/nvim -name '*.lua' | xargs -r stylua -c
+
+      # Use the official Stylua action instead of apt
+      - name: StyLua
+        uses: JohnnyMorganz/stylua-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Pin to a specific version to avoid formatting drift
+          version: 2.1.0
+          # Check all Neovim Lua files
+          args: --check dot_config/nvim


### PR DESCRIPTION
## Summary
- use Chocolatey to install chezmoi on Windows runners
- replace apt-based Stylua install with JohnnyMorganz/stylua-action
- bump actions/checkout to v4

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68951c6d718c832d8b012db46e190ed4