### PR TITLE
Source local zsh and tmux config

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -57,3 +57,6 @@ set -g status-left-length  30
 set -g status-right-length 80
 set -g status-left  "#[bg=#000000,fg=#4c566a] #S #[bg=#000000,fg=#4c566a,nobold] "
 set -g status-right "#[fg=#88c0d0]#(hostname) #[fg=#81a1c1]"
+
+# Source local overrides if present
+if-shell '[ -f ~/.tmux.conf.local ]' 'source-file ~/.tmux.conf.local'

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -165,3 +165,7 @@ function y() {
   [ -n "$cwd" ] && [ "$cwd" != "$PWD" ] && builtin cd -- "$cwd"
   rm -f -- "$tmp"
 }
+
+# Load machine-specific overrides, if present
+# shellcheck disable=SC1090
+[[ -r "$HOME/.zshrc.local" ]] && source "$HOME/.zshrc.local"


### PR DESCRIPTION
## Summary
- allow machine-specific zsh tweaks via `~/.zshrc.local`
- source `~/.tmux.conf.local` when present for extra tmux settings

## Testing
- `shellcheck dot_zshrc` *(fails: command not found)*
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_689675afe9d8832da67e6a69b6f45d34