### PR TITLE
corp: disable XDG exports and gate run once scripts

### DIFF
--- a/run_once_20-set-xdg.ps1.tmpl
+++ b/run_once_20-set-xdg.ps1.tmpl
@@ -1,9 +1,8 @@
 {{- /* run_once_20-set-xdg.ps1.tmpl */ -}}
 {{- if eq .chezmoi.os "windows" -}}
-# Permanently set XDG_* at *user* scope so every program inherits them.
-
-[Environment]::SetEnvironmentVariable('XDG_CONFIG_HOME', "$HOME\.config",      'User')
-[Environment]::SetEnvironmentVariable('XDG_DATA_HOME',  "$HOME\.local\share",  'User')
-[Environment]::SetEnvironmentVariable('XDG_CACHE_HOME', "$HOME\.cache",        'User')
-Write-Host '✔  XDG_* variables set (User scope). Restart shells to pick up changes.'
+# XDG_* variables are managed by the OS. Rely on defaults instead.
+# [Environment]::SetEnvironmentVariable('XDG_CONFIG_HOME', "$HOME\.config",      'User')   # disabled for corp Linux
+# [Environment]::SetEnvironmentVariable('XDG_DATA_HOME',  "$HOME\.local\share",  'User')   # disabled for corp Linux
+# [Environment]::SetEnvironmentVariable('XDG_CACHE_HOME', "$HOME\.cache",        'User')   # disabled for corp Linux
+# Write-Host '✔  XDG_* variables set (User scope). Restart shells to pick up changes.'
 {{- end -}}

--- a/run_once_40-install-vscode-extensions.ps1.tmpl
+++ b/run_once_40-install-vscode-extensions.ps1.tmpl
@@ -1,4 +1,4 @@
-{{ if eq .chezmoi.os "windows" -}}
+{{ if and (eq .chezmoi.os "windows") (not (and (hasKey . "corp_linux") .corp_linux)) -}}
 $extensionsFile = "{{ .chezmoi.sourceDir }}\vscode_extensions.txt"
 if (Get-Command "code" -ErrorAction SilentlyContinue) {
     $codeCmd = "code"

--- a/run_once_40-install-vscode-extensions.sh.tmpl
+++ b/run_once_40-install-vscode-extensions.sh.tmpl
@@ -1,4 +1,4 @@
-{{ if ne .chezmoi.os "windows" -}}
+{{ if and (ne .chezmoi.os "windows") (not (and (hasKey . "corp_linux") .corp_linux)) -}}
 #!/usr/bin/env bash
 set -e
 EXT_FILE="{{ .chezmoi.sourceDir }}/vscode_extensions.txt"


### PR DESCRIPTION
## Summary
- avoid setting XDG_* variables and rely on defaults
- skip VS Code extension installers when `corp_linux` is set

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68968934f260832da5a2c9d5b36c3681