### PR TITLE
Use default config paths without XDG env

### DIFF
--- a/AppData/Local/symlink_nvim.tmpl
+++ b/AppData/Local/symlink_nvim.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.config/nvim

--- a/AppData/Roaming/jesseduffield/symlink_lazygit.tmpl
+++ b/AppData/Roaming/jesseduffield/symlink_lazygit.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.config/jesseduffield/lazygit

--- a/Documents/PowerShell/Microsoft.PowerShell_profile.ps1
+++ b/Documents/PowerShell/Microsoft.PowerShell_profile.ps1
@@ -31,3 +31,8 @@ if (Get-Command zoxide -ErrorAction SilentlyContinue) {
     Write-Host "⚠️  zoxide not found. Install with: winget install ajeetdsouza.zoxide"
 }
 
+# Favor hidden files but ignore common junk, colorized output
+function rg {
+    & rg.exe --hidden --smart-case --colors match:fg:yellow --glob '!.git' --glob '!node_modules' @Args
+}
+

--- a/Library/Application Support/symlink_eza.tmpl
+++ b/Library/Application Support/symlink_eza.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.config/eza

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -146,6 +146,8 @@ fi
 # Aliases
 alias z='cd'
 alias grep="grep --color=auto"
+# Favor hidden files but ignore common junk, colorized output
+alias rg='rg --hidden --smart-case --colors match:fg:yellow --glob "!.git" --glob "!node_modules"'
 # Use modern replacements if available
 command -v bat >/dev/null && alias cat='bat'
 if command -v eza >/dev/null; then

--- a/run_once_20-set-xdg.ps1.tmpl
+++ b/run_once_20-set-xdg.ps1.tmpl
@@ -1,9 +1,0 @@
-{{- /* run_once_20-set-xdg.ps1.tmpl */ -}}
-{{- if eq .chezmoi.os "windows" -}}
-# Permanently set XDG_* at *user* scope so every program inherits them.
-
-[Environment]::SetEnvironmentVariable('XDG_CONFIG_HOME', "$HOME\.config",      'User')
-[Environment]::SetEnvironmentVariable('XDG_DATA_HOME',  "$HOME\.local\share",  'User')
-[Environment]::SetEnvironmentVariable('XDG_CACHE_HOME', "$HOME\.cache",        'User')
-Write-Host '✔  XDG_* variables set (User scope). Restart shells to pick up changes.'
-{{- end -}}


### PR DESCRIPTION
## Summary
- drop Windows script that exported XDG_* variables
- add platform symlinks for Neovim, Lazygit, and eza
- bake ripgrep defaults into zsh and PowerShell aliases

## Testing
- `chezmoi apply --dry-run -S . --verbose`
- `chezmoi doctor -S .`
- `shellcheck dot_zshrc`


------
https://chatgpt.com/codex/tasks/task_e_68969de353f8832d8acebd6030be0fff