### PR TITLE
Add leader toggles for inline hints

### DIFF
--- a/docs/vscode-keybindings.md
+++ b/docs/vscode-keybindings.md
@@ -93,6 +93,11 @@ The following shortcuts are configured through the VS Code Vim extension via [`s
 - `<leader> w j` – focus pane below
 - `<leader> w k` – focus pane above
 - `<leader> w l` – focus right pane
+- `<leader> u w` – toggle word wrap
+- `<leader> u z` – toggle Zen mode
+- `<leader> u c` – toggle render whitespace
+- `<leader> u i` – toggle inline parameter name hints
+- `<leader> u d` – toggle debug inline values
 - `<leader> s g` – search within files
 - `<leader> s f` – search files
 - `<leader> s t` – search files by type

--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -289,6 +289,16 @@
       "before": ["<leader>", "u", "c"],
       "commands": ["editor.action.toggleRenderWhitespace"]
     },
+    {
+      // Toggle inline parameter name hints
+      "before": ["<leader>", "u", "i"],
+      "commands": ["editor.action.toggleInlineHints"]
+    },
+    {
+      // Toggle debug inline values
+      "before": ["<leader>", "u", "d"],
+      "commands": ["workbench.action.debug.toggleInlineValues"]
+    },
     // File
     {
       "before": ["<leader>", "f", "m"],


### PR DESCRIPTION
## Summary
- add Vim `<leader> u` shortcuts to toggle inline parameter name hints and inline debug values
- document new `<leader> u` shortcuts in keybindings cheat sheet

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_6896d6e7d6b8832d90fcdb75ee377542