### PR TITLE
Use italic font for inlay hints

### DIFF
--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -1139,6 +1139,7 @@
   "gitlens.currentLine.enabled": false,
   "gitlens.codeLens.enabled": false,
   "editor.inlayHints.enabled": "off",
+  "editor.inlayHints.fontFamily": "JetBrainsMono Nerd Font Italic, JetBrains Mono Italic, monospace",
   "debug.onTaskErrors": "showErrors",
   "task.saveBeforeRun": "always",
   "telemetry.telemetryLevel": "off",


### PR DESCRIPTION
## Summary
- Set VS Code's editor.inlayHints.fontFamily to JetBrainsMono Nerd Font Italic for italicized hints

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_6897c06a99ac832db78ed6905f74c787