### PR TITLE
Set Yazi file detection path on Windows

### DIFF
--- a/windows/run_once_30-setup.ps1.tmpl
+++ b/windows/run_once_30-setup.ps1.tmpl
@@ -71,6 +71,20 @@ if (-not $fontInstalled) {
 } else {
     Write-Host "JetBrainsMono-NF font is already installed."
 }
+# Ensure Yazi uses Git's file.exe for MIME detection
+$gitFile = "$env:ProgramFiles\Git\usr\bin\file.exe"
+if (Test-Path $gitFile) {
+    $current = [System.Environment]::GetEnvironmentVariable('YAZI_FILE_ONE', 'User')
+    if ($current -ne $gitFile) {
+        [System.Environment]::SetEnvironmentVariable('YAZI_FILE_ONE', $gitFile, 'User')
+        Write-Host "Set YAZI_FILE_ONE to $gitFile"
+    } else {
+        Write-Host "YAZI_FILE_ONE is already set to $gitFile"
+    }
+    $env:YAZI_FILE_ONE = $gitFile
+} else {
+    Write-Warning "file.exe not found at $gitFile. Install Git for Windows."
+}
 # Ensure LLVM (clang) is in PATH for C compiler support
 $llvmBin = "$env:ProgramFiles\LLVM\bin"
 if (Test-Path "$llvmBin\clang.exe") {


### PR DESCRIPTION
## Summary
- ensure Windows setup sets `YAZI_FILE_ONE` so Yazi can detect MIME types

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_689c13632b94832d80046f7824c3b274