### PR TITLE
Add lazygit to common apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ These tools are offered during setup:
 - `yazi` as a modern terminal file manager
 - `delta` for modern git diffs (also used in Lazygit)
   - diffs are side-by-side by default, while LazyGit shows inline changes
+- `lazygit` for a simple git TUI
 
 # Mac
 

--- a/common_apps.txt
+++ b/common_apps.txt
@@ -10,4 +10,5 @@ llvm
 nvim
 zoxide
 yazi
+lazygit
 starship

--- a/windows/run_once_30-setup.ps1.tmpl
+++ b/windows/run_once_30-setup.ps1.tmpl
@@ -52,6 +52,7 @@ if (Get-Command winget -ErrorAction SilentlyContinue) {
         'starship' = 'Starship.Starship'
         'zoxide'   = 'ajeetdsouza.zoxide'
         'yazi'     = 'sxyazi.yazi'
+        'lazygit'  = 'JesseDuffield.lazygit'
     }
     foreach ($pkg in $COMMON_APPS) {
         if ($wingetAppMap.ContainsKey($pkg)) {


### PR DESCRIPTION
## Summary
- include `lazygit` in the shared app list and CLI tool docs
- add a winget mapping so Windows setups can install `lazygit`

## Testing
- `chezmoi apply --dry-run -S . --verbose`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_689c1f456e50832db0538dd907b502a8