### PR TITLE
Enable Shift-F4/F6 scrolling in Neovim insert mode

### DIFF
--- a/dot_config/nvim/lua/config/keymaps.lua
+++ b/dot_config/nvim/lua/config/keymaps.lua
@@ -44,7 +44,9 @@ end
 
 -- Scroll up/down 16 lines
 map_shift_f(4, "<C-u>", { desc = "Scroll Up 16 lines", noremap = true })
+map_shift_f(4, "<C-o><C-u>", { mode = "i", desc = "Scroll Up 16 lines", noremap = true })
 map_shift_f(6, "<C-d>", { desc = "Scroll Down 16 lines", noremap = true })
+map_shift_f(6, "<C-o><C-d>", { mode = "i", desc = "Scroll Down 16 lines", noremap = true })
 
 -- Stop current build
 map_shift_f(7, "<cmd>CMakeStop<CR>", { desc = "Stop Build" })


### PR DESCRIPTION
## Summary
- enable Shift+F4/F6 scroll mappings to work from insert mode in Neovim

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_689ea0b21530832d83c2c6f4b43f70fb