### PR TITLE
Handle no-match errors in VS Code fzf ripgrep task

### DIFF
--- a/dot_config/Code/User/tasks.json
+++ b/dot_config/Code/User/tasks.json
@@ -82,7 +82,7 @@
         "--column",
         "--color=always",
         "--smart-case",
-        "{q}\"",
+        "{q} || true\"",
 
         "--bind",
         "\"change:reload:rg",
@@ -90,7 +90,7 @@
         "--column",
         "--color=always",
         "--smart-case",
-        "{q}\"",
+        "{q} || true\"",
 
         "--delimiter",
         ":",


### PR DESCRIPTION
## Summary
- avoid ripgrep error when no matches in `FZF Ripgrep` VS Code task

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68a24cb5f058832d82385f0c5ae25276