### PR TITLE
fix: defer yazi plugin setup

### DIFF
--- a/dot_config/yazi/init.lua
+++ b/dot_config/yazi/init.lua
@@ -1,2 +1,10 @@
 -- require("git"):setup()
-require("relative-line-numbers"):setup()
+
+-- NOTE: The relative-line-numbers plugin patches Yazi's redraw logic.  When it
+-- runs too early (before the UI is fully initialized) Yazi can start up with a
+-- blank or partially rendered screen.  Deferring the setup to the main event
+-- loop ensures the UI is ready before we hook into it, avoiding the black
+-- screen on launch.
+ya.sync(function()
+  require("relative-line-numbers"):setup()
+end)


### PR DESCRIPTION
## Summary
- delay relative-line-numbers plugin initialization until Yazi's UI is ready to avoid blank screen on launch

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68a31e008354832d9234e249c08c33bc