### PR TITLE
Defer Yazi render to fix blank startup

### DIFF
--- a/dot_config/yazi/plugins/relative-line-numbers.yazi/main.lua
+++ b/dot_config/yazi/plugins/relative-line-numbers.yazi/main.lua
@@ -96,11 +96,15 @@ local render_numbers = ya.sync(function(_, mode)
         end
 
         -- Trigger a final render so the layout accounts for the number column.
-        if ui.render then
-                ui.render()
-        else
-                ya.render()
-        end
+        -- Defer the render slightly so Yazi's UI has fully initialized; rendering
+        -- too early could leave the screen blank until the next user input.
+        ya.defer(function()
+                if ui.render then
+                        ui.render()
+                else
+                        ya.render()
+                end
+        end)
 end)
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- avoid blank Yazi UI by deferring final render in relative-line-numbers plugin

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`

------
https://chatgpt.com/codex/tasks/task_e_68a31e008354832d9234e249c08c33bc