### PR TITLE
fix common apps path in bootstrap scripts

### DIFF
--- a/.config/yadm/bootstrap.d/30-setup-darwin.sh
+++ b/.config/yadm/bootstrap.d/30-setup-darwin.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 source "$HOME/.config/yadm/lib/run_ensure.sh"
 source "$HOME/.config/yadm/lib/cask_app_map.sh"
 
-mapfile -t COMMON_APPS < "$HOME/common_apps.txt"
+mapfile -t COMMON_APPS < "$HOME/.config/system/common_apps.txt"
 
 echo "Running macOS setup using Homebrew..."
 

--- a/.config/yadm/bootstrap.d/30-setup-linux.sh
+++ b/.config/yadm/bootstrap.d/30-setup-linux.sh
@@ -10,7 +10,7 @@ fi
 
 source "$HOME/.config/yadm/lib/run_ensure.sh"
 
-mapfile -t COMMON_APPS < "$HOME/common_apps.txt"
+mapfile -t COMMON_APPS < "$HOME/.config/system/common_apps.txt"
 
 echo "Installing packages using apt..."
 

--- a/.config/yadm/bootstrap.d/30-setup-windows.ps1
+++ b/.config/yadm/bootstrap.d/30-setup-windows.ps1
@@ -1,7 +1,8 @@
 # Requires PowerShell 7+
 
 # Build $COMMON_APPS array correctly from file lines
-$COMMON_APPS = Get-Content "$env:USERPROFILE/common_apps.txt" | Where-Object { $_.Trim() -ne "" }
+$commonAppsPath = Join-Path $env:USERPROFILE '.config/system/common_apps.txt'
+$COMMON_APPS = Get-Content $commonAppsPath | Where-Object { $_.Trim() -ne "" }
 
 Write-Host "COMMON_APPS:"
 $COMMON_APPS | ForEach-Object { Write-Host $_ }


### PR DESCRIPTION
## Summary
- point Linux, macOS, and Windows bootstrap scripts to `.config/system/common_apps.txt`

## Testing
- `yadm --version`
- `yadm status --short` *(fails: Git repo does not exist)*
- `HOME=$(pwd) AUTO_INSTALL=0 .config/yadm/bootstrap </dev/null`
- `shellcheck .config/yadm/bootstrap.d/30-setup-linux.sh .config/yadm/bootstrap.d/30-setup-darwin.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a4094230f8832dac492c4c26460d40