### PR TITLE
Increase history limits across shells and terminals

### DIFF
--- a/dotfiles/common/.bashrc
+++ b/dotfiles/common/.bashrc
@@ -21,8 +21,9 @@ export VISUAL="$EDITOR"
 
 # Shell options
 shopt -s nocaseglob dotglob extglob histappend
-HISTSIZE=50000
+HISTSIZE=1000000
 HISTFILE=~/.bash_history
+HISTFILESIZE=1000000
 HISTCONTROL=ignoreboth:erasedups
 PROMPT_COMMAND="history -a; $PROMPT_COMMAND"
 

--- a/dotfiles/common/.config/kitty/kitty.conf
+++ b/dotfiles/common/.config/kitty/kitty.conf
@@ -13,7 +13,7 @@ bold_italic_font JetBrainsMono Nerd Font Bold Italic
 disable_ligatures never
 
 # Quality of life improvements
-scrollback_lines 10000
+scrollback_lines 1000000
 enable_audio_bell no
 confirm_os_window_close 0
 macos_option_as_alt yes

--- a/dotfiles/common/.tmux.conf
+++ b/dotfiles/common/.tmux.conf
@@ -19,6 +19,9 @@ set -g base-index 1
 setw -g pane-base-index 1
 set -g renumber-windows on
 
+# Increase scrollback history
+set -g history-limit 1000000
+
 # Needed for kitty on macOS so Option sends proper escape sequences
 set -g xterm-keys on
 

--- a/dotfiles/common/.zshrc
+++ b/dotfiles/common/.zshrc
@@ -29,8 +29,8 @@ setopt hist_ignore_space      # Ignore commands starting with spaces
 setopt globdots               # Include dotfiles in globbing
 
 # History
-HISTSIZE=50000
-SAVEHIST=50000
+HISTSIZE=1000000
+SAVEHIST=1000000
 HISTFILE=~/.zsh_history
 
 # # Key Bindings

--- a/dotfiles/windows/Documents/PowerShell/Microsoft.PowerShell_profile.ps1
+++ b/dotfiles/windows/Documents/PowerShell/Microsoft.PowerShell_profile.ps1
@@ -1,7 +1,7 @@
 # PSReadLine options
 Set-PSReadLineOption -EditMode Emacs
 Set-PSReadLineOption -HistoryNoDuplicates:$true
-Set-PSReadLineOption -MaximumHistoryCount 5000
+Set-PSReadLineOption -MaximumHistoryCount 1000000
 
 # Replace -SaveHistoryInBackground with incremental history saving
 Set-PSReadLineOption -HistorySaveStyle SaveIncrementally


### PR DESCRIPTION
## Summary
- raise bash/zsh history size to 1,000,000 entries
- expand Kitty scrollback and tmux history to 1,000,000 lines
- expand PowerShell history to 1,000,000 commands

## Testing
- `./apply.sh --no`
- `./apply.sh --no --adopt`
- `./apply.sh --no --restow`
- `shellcheck dotfiles/common/.bashrc dotfiles/common/.zshrc` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a952501cec832d91b93e2a7b653a58