### PR TITLE
docs: remove stale file references

### DIFF
--- a/docs/vim-bindings.md
+++ b/docs/vim-bindings.md
@@ -1,10 +1,9 @@
 # VSVim Bindings Cheat Sheet
 
-This guide lists all custom key mappings defined in [`dot_vsvimrc`](../dot_vsvimrc).
-The `Space` key is the leader and `,` is the local leader.
-Equivalent mappings are configured for the VSCodeVim extension via
-[`dot_config/Code/User/settings.json`](../dot_config/Code/User/settings.json),
-which is also symlinked for use by the Cursor editor.
+This guide lists my custom key mappings for the VSVim plugin in Visual Studio.
+The `Space` key acts as the leader and `,` is the local leader.
+Equivalent mappings can be configured for the VSCodeVim extension (and Cursor)
+using that extension's settings.
 
 ## General
 - `zl` – reload `.vsvimrc`.
@@ -112,7 +111,7 @@ which is also symlinked for use by the Cursor editor.
 - `Shift+Alt+L` – go to previous difference region.
 
 ## Hardware Macro Keys
-These key combinations are implemented via keyboard macros rather than in `dot_vsvimrc`:
+These key combinations are implemented via keyboard macros rather than the VSVim configuration:
 
 ```
 build and run   – Shift+F2

--- a/docs/vimium-keybindings.md
+++ b/docs/vimium-keybindings.md
@@ -1,6 +1,6 @@
 # Vimium Keybindings Cheat Sheet
 
-Custom key mappings defined in [`dot_config/vimium_c.json`](../dot_config/vimium_c.json) for the Vimium C Chrome extension.
+Custom key mappings for the Vimium C Chrome extension.
 
 ## Scrolling
 - `Space` – scroll one page down.

--- a/docs/vscode-keybindings.md
+++ b/docs/vscode-keybindings.md
@@ -1,6 +1,6 @@
 # VSCode Keybindings Cheat Sheet
 
-This document lists all custom shortcuts defined in [`dot_config/Code/User/keybindings.json`](../dot_config/Code/User/keybindings.json). The same file is symlinked for the Cursor editor.
+This document lists the custom shortcuts I use in VS Code. The same keybindings can also be used in the Cursor editor.
 
 ## Navigation
 - `Ctrl+Tab` – switch to the next tab (Windows only).
@@ -48,7 +48,7 @@ This document lists all custom shortcuts defined in [`dot_config/Code/User/keybi
 
 ## Vim Extension Mappings
 
-The following shortcuts are configured through the VS Code Vim extension via [`settings.json`](../dot_config/Code/User/settings.json).
+The following shortcuts are configured through the VS Code Vim extension's settings.
 
 ### Normal Mode
 - `<leader> v` – <C-v>


### PR DESCRIPTION
## Summary
- clarify that VSVim, VS Code, and Vimium keybinding docs no longer reference absent config files

## Testing
- `./apply.sh --no`


------
https://chatgpt.com/codex/tasks/task_e_68a9c279f1d8832dbb8a42fa11c891c9