### PR TITLE
Clarify automatic stow installation in Quick Setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ When you run `stow common` from `dotfiles/`, symlinks are created:
 
 ```sh
 # Install Homebrew from https://brew.sh if not already present
-brew install stow
+# stow will be installed automatically by the init script
 git clone https://github.com/skyde/dotfiles.git ~/dotfiles
 cd ~/dotfiles
 ./init.sh
@@ -45,7 +45,7 @@ cd ~/dotfiles
 
 ```sh
 sudo apt update
-sudo apt install -y stow git
+sudo apt install -y git   # stow installed automatically
 git clone https://github.com/skyde/dotfiles.git ~/dotfiles
 cd ~/dotfiles
 ./init.sh
@@ -54,7 +54,7 @@ cd ~/dotfiles
 ### Windows (platform)
 
 ```ps
-winget install stefansundin.gnu-stow
+# stow will be installed automatically via winget if missing
 git clone https://github.com/skyde/dotfiles.git "$env:USERPROFILE\dotfiles"
 cd "$env:USERPROFILE\dotfiles"
 ./init.ps1


### PR DESCRIPTION
## Summary
- Document that init scripts automatically install stow
- Remove redundant manual stow installation steps on macOS, Linux, and Windows

## Testing
- `./apply.sh --no`
- `./apply.sh --no --adopt`


------
https://chatgpt.com/codex/tasks/task_e_68a9c279f1d8832dbb8a42fa11c891c9