### PR TITLE
chore: remove chezmoi references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ This repo stores dotfiles managed with GNU Stow. Use the provided scripts and ke
 
 Optional helpers present but not wired into the local scripts:
 
-- `lib/run_ensure.sh` and `lib/cask_app_map.sh` are designed to be sourced in a chezmoi environment via `CHEZMOI_SOURCE_DIR`. They are not invoked by `init.sh`/`apply.sh` in this repo. Leave them as-is if you use chezmoi elsewhere; otherwise, they can be ignored.
+- `lib/run_ensure.sh` and `lib/cask_app_map.sh` are optional utilities for package management. They are not invoked by `init.sh`/`apply.sh` in this repo but can be sourced manually if desired.
 
 Avoid committing secrets or personal data.
 

--- a/lib/run_ensure.sh
+++ b/lib/run_ensure.sh
@@ -12,9 +12,10 @@ _truthy() {
 have() { command -v "$1" >/dev/null 2>&1; }
 
 # Optional: source cask->app mapping if available
-if [ -n "${CHEZMOI_SOURCE_DIR:-}" ] && [ -f "${CHEZMOI_SOURCE_DIR}/lib/cask_app_map.sh" ]; then
-  # shellcheck disable=SC1090,SC1091
-  source "${CHEZMOI_SOURCE_DIR}/lib/cask_app_map.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "${SCRIPT_DIR}/cask_app_map.sh" ]; then
+  # shellcheck disable=SC1091
+  source "${SCRIPT_DIR}/cask_app_map.sh"
 fi
 
 is_tty() { [ -t 0 ] && [ -t 1 ]; }


### PR DESCRIPTION
## Summary
- drop chezmoi references in agent guidelines
- source cask_app_map.sh relative to run_ensure.sh

## Testing
- `./apply.sh --no` *(fails: existing target is neither a link nor a directory: .bashrc)*
- `./apply.sh --no --adopt` *(fails: existing target is neither a link nor a directory: .bashrc)*
- `./apply.sh --no --restow` *(fails: existing target is neither a link nor a directory: .bashrc)*
- `shellcheck lib/run_ensure.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7ffbb9b8832db2df3b7ac0884daa