### PR TITLE
chore: keep FZF Ripgrep task running

### DIFF
--- a/dotfiles/common/.config/Code/User/tasks.json
+++ b/dotfiles/common/.config/Code/User/tasks.json
@@ -81,7 +81,7 @@
     {
       "label": "FZF Ripgrep",
       "type": "shell",
-      "command": "set +o pipefail; fzf",
+      "command": "fzf",
       "args": [
         "--reverse",
         "--ansi",
@@ -96,13 +96,13 @@
         "--column",
         "--color=always",
         "--smart-case",
-        "{q} || true\"",
+        "{q}||true\"",
         "--bind",
         "\"change:reload:rg",
         "--column",
         "--color=always",
         "--smart-case",
-        "{q} || true\"",
+        "{q}||true\"",
         "--delimiter",
         ":",
         "--preview",
@@ -119,12 +119,6 @@
         "--bind",
         "'esc:clear-query'"
       ],
-      "options": {
-        "shell": {
-          "executable": "bash",
-          "args": ["-lc"]
-        }
-      },
       "presentation": {
         "echo": false,
         "clear": true,


### PR DESCRIPTION
## Summary
- prevent VS Code FZF Ripgrep task from interrupting task chains by forcing success

## Testing
- `./apply.sh --no`
- `./apply.sh --no --adopt`
- `./apply.sh --no --restow`


------
https://chatgpt.com/codex/tasks/task_e_68ac814b4e6c832d8d07a3ca50cbde69