### PR TITLE
refine zsh configuration

### DIFF
--- a/dotfiles/common/.zshrc
+++ b/dotfiles/common/.zshrc
@@ -1,52 +1,158 @@
 # shellcheck shell=zsh
-if [[ -o interactive ]]; then
-  stty -ixon -ixoff
-fi
 
-# Path setup (add custom bins before system paths)
-for d in "$HOME/.local/bin" "$HOME/bin" "/usr/local/bin"; do
-  if [[ -d $d ]] && [[ ":$PATH:" != *":$d:"* ]]; then
-    export PATH="$d:$PATH"
-  fi
+# --- interactive TTY tweaks
+[[ -o interactive ]] && stty -ixon -ixoff
+
+# --- PATH (prefer user bins; include Homebrew on Apple Silicon)
+for d in "$HOME/.local/bin" "$HOME/bin" "/opt/homebrew/bin" "/usr/local/bin"; do
+  [[ -d $d ]] && [[ :$PATH: != *":$d:"* ]] && PATH="$d:$PATH"
 done
+export PATH
 
-# Default editor
+# --- editor
 export EDITOR="nvim"
 export VISUAL="$EDITOR"
 
-# Shell Options
-setopt autocd             # Enter directory just by typing its name
-# Disable automatic command correction
-# setopt correct
-setopt nocaseglob         # Case insensitive globbing
-setopt extended_glob      # Extended globbing
-setopt hist_ignore_all_dups  # Don’t store duplicate history
-setopt share_history         # Share command history between sessions
-setopt inc_append_history     # Append to history file immediately
-setopt hist_ignore_space      # Ignore commands starting with spaces
-setopt globdots               # Include dotfiles in globbing
+# --- shell options
+setopt autocd nocaseglob extended_glob globdots
+setopt hist_ignore_all_dups hist_ignore_space
+setopt share_history inc_append_history append_history
 
-# History
+# --- history
 HISTSIZE=1000000
 SAVEHIST=1000000
-HISTFILE=~/.zsh_history
+HISTFILE="$HOME/.zsh_history"
 
-# # Key Bindings
-# bindkey -v                # Use vim keybindings
-# KEYTIMEOUT=1              # Reduce delay for ESC
-# bindkey -M vicmd '_' vi-beginning-of-line  # '_' moves to start of line in normal mode
+# --- key bindings
+bindkey -e                              # Emacs keybindings
+bindkey '^[[1;5C' forward-word          # Ctrl+Right
+bindkey '^[[1;5D' backward-word         # Ctrl+Left
 
-bindkey -e                # Use emacs keybindings
-bindkey '^[[1;5C' forward-word     # Ctrl+Right
-bindkey '^[[1;5D' backward-word    # Ctrl+Left
+# --- completion
+autoload -Uz compinit
+compinit
+zstyle ':completion:*' menu select
+zstyle ':completion:*' matcher-list 'm:{a-z}={A-Za-z}'
 
-# Bootstrap Starship
+# --- prompt (Starship)
 eval "$(starship init zsh)"
 
-# Zsh Plugins: autosuggestions & syntax-highlighting
-# Load from common installation paths without relying on brew
+# --- zoxide (smart cd)
+if command -v zoxide >/dev/null; then
+  eval "$(zoxide init zsh)"
+fi
+
+# --- FZF integration
+_source_first() {  # source the first readable file from args
+  local f; for f in "$@"; do [[ -r $f ]] && source "$f" && return 0; done; return 1
+}
+if command -v fzf >/dev/null; then
+  _source_first \
+    "/usr/share/fzf/key-bindings.zsh" \
+    "/usr/local/opt/fzf/shell/key-bindings.zsh" \
+    "/opt/homebrew/opt/fzf/shell/key-bindings.zsh" \
+    "/usr/share/doc/fzf/examples/key-bindings.zsh" \
+    "$HOME/.fzf/shell/key-bindings.zsh" "$HOME/.fzf/key-bindings.zsh"
+  _source_first \
+    "/usr/share/fzf/completion.zsh" \
+    "/usr/local/opt/fzf/shell/completion.zsh" \
+    "/opt/homebrew/opt/fzf/shell/completion.zsh" \
+    "/usr/share/doc/fzf/examples/completion.zsh" \
+    "$HOME/.fzf/shell/completion.zsh" "$HOME/.fzf/completion.zsh"
+  if command -v fd >/dev/null; then
+    export FZF_DEFAULT_COMMAND='fd --type f --hidden --follow --exclude .git'
+    export FZF_CTRL_T_COMMAND="$FZF_DEFAULT_COMMAND"
+  fi
+fi
+
+# --- fzf-powered history search (Ctrl-R), deduped & reverse-chronological
+if (( $+commands[fzf] )); then
+  _fzf_history_widget() {
+    local selected
+    selected=$( \
+      fc -nrl 1 | awk '!seen[$0]++' | \
+      fzf --height=80% --reverse --tiebreak=index --no-sort \
+          --prompt='History> ' --style=minimal --query="$LBUFFER" \
+    ) || return
+    LBUFFER=$selected
+    zle redisplay
+  }
+  zle -N _fzf_history_widget
+  bindkey '^R' _fzf_history_widget
+fi
+
+# --- safer Git defaults where tools may be missing
+if ! command -v delta >/dev/null || ! command -v code >/dev/null; then
+  git() {
+    local -a cfg=()
+    if ! command -v delta >/dev/null; then
+      cfg+=(-c core.pager=less -c interactive.diffFilter=cat)
+    fi
+    if ! command -v code >/dev/null; then
+      if command -v nvim >/dev/null; then
+        cfg+=(-c merge.tool=nvimdiff3 -c difftool.tool=nvimdiff)
+      else
+        cfg+=(-c merge.tool=vimdiff -c difftool.tool=vimdiff)
+      fi
+    fi
+    command git "${cfg[@]}" "$@"
+  }
+fi
+
+# --- aliases
+alias grep='grep --color=auto'
+alias stow_apply='$HOME/dotfiles/apply.sh'
+alias stow_init='$HOME/dotfiles/init.sh'
+alias stow_update='$HOME/dotfiles/update.sh && $HOME/dotfiles/apply.sh'
+alias stow_update_init_auto='$HOME/dotfiles/update.sh && AUTO_INSTALL=1 $HOME/dotfiles/init.sh'
+
+# ripgrep: hidden files, smart case, ignore common junk
+alias rg='rg --hidden --smart-case --colors match:fg:yellow --glob "!.git" --glob "!node_modules"'
+
+# bat / batcat
+if command -v bat >/dev/null; then
+  alias cat='bat'
+elif command -v batcat >/dev/null; then
+  alias bat='batcat'
+  alias cat='batcat'
+fi
+
+# eza ls replacements
+if command -v eza >/dev/null; then
+  alias ls='eza --color=auto --group-directories-first'
+  alias ll='eza -al --color=auto --group-directories-first'
+  alias la='eza -a --color=auto --group-directories-first'
+  alias tree='eza --tree --icons --group-directories-first'
+fi
+
+# fd on Debian/Ubuntu where it's named fdfind
+if [[ -z $(command -v fd 2>/dev/null) && -n $(command -v fdfind 2>/dev/null) ]]; then
+  alias fd='fdfind'
+fi
+
+# --- file managers that cd to the last visited dir
+y() {
+  local tmp cwd
+  tmp="$(mktemp -t yazi-cwd.XXXXXX)"
+  command yazi "$@" --cwd-file="$tmp"
+  cwd="$(<"$tmp")"
+  rm -f -- "$tmp"
+  [[ -n $cwd && $cwd != "$PWD" ]] && builtin cd -- "$cwd"
+}
+
+lfcd() {
+  local tmp dir
+  tmp="$(mktemp -t lfcd.XXXXXX)"
+  command lf -last-dir-path "$tmp" -- "$@"
+  dir="$(<"$tmp")"
+  rm -f -- "$tmp"
+  [[ -n $dir && $dir != "$PWD" ]] && builtin cd -- "$dir"
+}
+alias lf='lfcd'
+
+# --- plugins (load AFTER compinit & prompt; keep syntax-highlighting last)
 for plugin in zsh-autosuggestions zsh-syntax-highlighting; do
-  for dir in "/usr/local/share/$plugin" "/opt/homebrew/share/$plugin" "/usr/share/$plugin"; do
+  for dir in "/opt/homebrew/share/$plugin" "/usr/local/share/$plugin" "/usr/share/$plugin"; do
     if [[ -r "$dir/$plugin.zsh" ]]; then
       source "$dir/$plugin.zsh"
       break
@@ -54,137 +160,6 @@ for plugin in zsh-autosuggestions zsh-syntax-highlighting; do
   done
 done
 
-# Autocomplete
-autoload -Uz compinit && compinit
-zstyle ':completion:*' menu select
-zstyle ':completion:*' matcher-list 'm:{a-z}={A-Za-z}'
-
-# zoxide
-eval "$(zoxide init zsh)"
-
-# FZF integration
-if command -v fzf >/dev/null; then
-  for dir in \
-    "/usr/share/fzf" \
-    "/usr/local/opt/fzf/shell" \
-    "/opt/homebrew/opt/fzf/shell" \
-    "/usr/share/doc/fzf/examples" \
-    "$HOME/.fzf"; do
-    if [[ -r "$dir/key-bindings.zsh" ]]; then
-      source "$dir/key-bindings.zsh"
-      break
-    fi
-  done
-  for dir in \
-    "/usr/share/fzf" \
-    "/usr/local/opt/fzf/shell" \
-    "/opt/homebrew/opt/fzf/shell" \
-    "/usr/share/doc/fzf/examples" \
-    "$HOME/.fzf"; do
-    if [[ -r "$dir/completion.zsh" ]]; then
-      source "$dir/completion.zsh"
-      break
-    fi
-  done
-  if command -v fd >/dev/null; then
-    export FZF_DEFAULT_COMMAND='fd --type f --hidden --follow --exclude .git --color=always'
-    export FZF_CTRL_T_COMMAND="$FZF_DEFAULT_COMMAND"
-  fi
-fi
-
-if (( $+commands[fzf] )); then
-  function _fzf_history_widget() {
-    local selected
-    selected=$(
-      fc -nrl 1 |                  \
-      awk '!seen[$0]++' |          \
-      fzf  --height=80%            \
-           --reverse               \
-           --tiebreak=index        \
-           --no-sort               \
-           --prompt='History> '    \
-           --style=minimal    \
-           --query="$LBUFFER"      
-    ) || return
-
-    LBUFFER=$selected
-    zle redisplay
-  }
-
-  zle -N _fzf_history_widget
-  bindkey '^R' _fzf_history_widget
-fi
-
-# Safer Git defaults on hosts where some tools are unavailable (e.g., corp machines)
-# - If delta is missing, fall back to less and plain diffs for interactive mode
-# - If VS Code is missing, use Neovim/Vim mergetools instead of the vscode tool
-if ! command -v delta >/dev/null || ! command -v code >/dev/null; then
-  function git() {
-    local -a cfg
-    cfg=()
-    if ! command -v delta >/dev/null; then
-      cfg+=( -c core.pager=less -c interactive.diffFilter=cat )
-    fi
-    if ! command -v code >/dev/null; then
-      if command -v nvim >/dev/null; then
-        cfg+=( -c merge.tool=nvimdiff3 -c difftool.tool=nvimdiff )
-      else
-        cfg+=( -c merge.tool=vimdiff -c difftool.tool=vimdiff )
-      fi
-    fi
-    command git "${cfg[@]}" "$@"
-  }
-fi
-
-# Aliases
-alias z='cd'
-alias grep="grep --color=auto"
-alias stow_apply='~/dotfiles/apply.sh'
-alias stow_init='~/dotfiles/init.sh'
-alias stow_update='~/dotfiles/update.sh && ~/dotfiles/apply.sh'
-alias stow_update_init_auto='~/dotfiles/update.sh && AUTO_INSTALL=1 ~/dotfiles/init.sh'
-# Favor hidden files but ignore common junk, colorized output
-alias rg='rg --hidden --smart-case --colors match:fg:yellow --glob "!.git" --glob "!node_modules"'
-# Use modern replacements if available
-if command -v bat >/dev/null; then
-  alias cat='bat'
-elif command -v batcat >/dev/null; then
-  # Debian/Ubuntu ship the binary as 'batcat'
-  alias bat='batcat'
-  alias cat='batcat'
-fi
-if command -v eza >/dev/null; then
-  alias ls='eza --color=auto --group-directories-first'
-  alias ll='eza -al --color=auto --group-directories-first'
-  alias la='eza -a --color=auto --group-directories-first'
-fi
-if [[ -z $(command -v fd 2>/dev/null) && -n $(command -v fdfind 2>/dev/null) ]]; then
-  alias fd='fdfind'
-fi
-
-# Open yazi in the current directory and change to its exit path
-function y() {
-  local tmp="$(mktemp -t "yazi-cwd.XXXXXX")" cwd
-  yazi "$@" --cwd-file="$tmp"
-  IFS= read -r -d '' cwd < "$tmp"
-  [ -n "$cwd" ] && [ "$cwd" != "$PWD" ] && builtin cd -- "$cwd"
-  rm -f -- "$tmp"
-}
-alias yazi='y'
-
-# Open lf in the current directory and change to its exit path
-lfcd() {
-  local tmp="$(mktemp -t lfcd.XXXXXX)" dir
-  # Pass flag before positional args and use -- to avoid misparsing
-  lf -last-dir-path "$tmp" -- "$@"
-  dir=$(cat "$tmp")
-  rm -f -- "$tmp"
-  [ -n "$dir" ] && [ "$dir" != "$PWD" ] && builtin cd -- "$dir"
-}
-alias lf='lfcd'
-
-alias tree='eza --tree --icons --group-directories-first'
-
-# Load machine-specific overrides, if present
+# --- machine-specific overrides
 # shellcheck disable=SC1090
 [[ -r "$HOME/.zshrc.local" ]] && source "$HOME/.zshrc.local"


### PR DESCRIPTION
## Summary
- streamline PATH and history options in `.zshrc`
- improve FZF setup and file manager wrappers
- load plugins after prompt with syntax highlighting last

## Testing
- `shellcheck dotfiles/common/.zshrc` *(fails: command not found)*
- `./apply.sh --no` *(fails: stow: command not found)*
- `./apply.sh --no --restow` *(fails: stow: command not found)*
- `./apply.sh --no --adopt` *(fails: stow: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc7725b88832db658deaf2e5951d7