### PR TITLE
Revamp documentation and expand usage guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,46 +1,9 @@
-# Agent Guidelines
+# Automation / Agents
 
-This repo stores dotfiles managed with GNU Stow. Use the provided scripts and keep changes safe and reproducible.
+This repo is designed to be run **interactively** (`init`, `apply`, `update`).  
+If you automate (e.g., CI, devcontainer, or a provisioning tool), follow these guidelines:
 
-## Required checks
-
-1. Dry-run stow and ensure no errors:
-   - `./apply.sh --no` (from the repo root)
-2. If your change might adopt existing files, preview adoption:
-   - `./apply.sh --no --adopt`
-3. If you changed already-installed packages, verify a restow preview:
-   - `./apply.sh --no --restow`
-
-## Optional checks
-
-- Run ShellCheck on modified shell scripts if available: `shellcheck <changed .sh files>`
-- Run Stylua on modified Neovim Lua files if available: `stylua dotfiles/common/nvim/.config/nvim`
-- For cross-platform confidence, optionally run the workflow helper: `./test-all-platforms.sh [cycles]`
-
-## Commit and PR guidelines
-
-- Use concise commit messages summarizing the change.
-- In the PR description, list the affected packages/scripts and any notable behavior changes.
-- Call out anything requiring manual steps (rare) or platform-specific notes.
-
-## Repository layout tips
-
-- Cross-platform packages live under `dotfiles/common/` (e.g., `shell`, `devtools`, `nvim`, `Code`, `kitty`, `lf`).
-- OS-specific configs live under `dotfiles/mac/` and `dotfiles/windows/` (e.g., `mac/hammerspoon`, `windows/Documents`).
-- Neovim configuration is under `dotfiles/common/nvim/.config/nvim`.
-- VS Code extensions are listed in `vscode_extensions.txt` and installed by scripts.
-
-Optional helpers present but not wired into the local scripts:
-
-- `lib/run_ensure.sh` and `lib/cask_app_map.sh` are optional utilities for package management. They are not invoked by `init.sh`/`apply.sh` in this repo but can be sourced manually if desired.
-
-Avoid committing secrets or personal data.
-
-## Handy commands
-
-- First-time setup: `./init.sh`
-- Apply changes normally: `./apply.sh`
-- Preview only: `./apply.sh --no`
-- Restow existing installs: `./apply.sh --restow`
-- Preview adoption (taking over real files): `./apply.sh --no --adopt`
-- Update from remote and restow: `./update.sh`
+- Run in **dry-run** first (`./apply.sh --no`) and log output.
+- Adopt rather than overwrite on long‑lived machines (`stow --adopt`).
+- Pin major tool versions in your package manager where reproducibility matters.
+- Keep `packages.txt` minimal; layer project‑specific configs elsewhere.

--- a/README-usage.md
+++ b/README-usage.md
@@ -1,208 +1,146 @@
-# Dotfiles Usage Guide
+# Usage & Operations
 
-## Scripts
+This page covers the day‑to‑day commands, flags, and patterns.
 
-### `init.sh` / `init.ps1` - First-time setup
+---
 
-**Unix/Linux/macOS:**
+## Prerequisites
+
+- **macOS/Linux:** `git`, `stow` (installed by `init-macos.sh`/`init-linux.sh` if missing)
+- **Windows:** PowerShell 5+ (built‑in), Developer Mode recommended (or run as Administrator)
+
+---
+
+## 1) Bootstrap a machine
+
+### macOS
+```bash
+./init-macos.sh
+```
+
+* Installs `git`, `stow`, and base tools as needed.
+* Performs basic macOS configuration (e.g., defaults) when applicable.
+
+### Linux
 
 ```bash
-./init.sh
+./init-linux.sh
 ```
 
-**Windows:**
+* Installs `git`, `stow` via your package manager.
+* Ensures the environment is ready for linking.
+
+### Windows
 
 ```powershell
-.\init.ps1
+Set-ExecutionPolicy -Scope CurrentUser RemoteSigned
+.\init-windows.ps1
 ```
 
-- Installs dotfiles with `--adopt` (takes over existing files)
-- Prompts to install VS Code extensions
-- Prompts to install common development tools
+* Prepares the environment (developer mode checks, etc.).
+* Ensures linking will work for your user.
 
-### `apply.sh` / `apply.ps1` - Stow wrapper
+---
 
-**Unix/Linux/macOS:**
+## 2) Apply dotfiles
+
+### Default packages
 
 ```bash
-./apply.sh [STOW_OPTIONS]
+# macOS/Linux
+./apply.sh
 ```
-
-**Windows:**
 
 ```powershell
-.\apply.ps1 [STOW_OPTIONS]
+# Windows
+.\apply.ps1
 ```
 
-Direct wrapper around stow with sensible defaults. Passes all arguments to stow.
+Reads `packages.txt` and links those packages.
 
-### `update.sh` / `update.ps1` - Update from remote
+### Select packages explicitly
 
-**Unix/Linux/macOS:**
+```bash
+./apply.sh shell nvim Code
+```
+
+```powershell
+.\apply.ps1 -Packages shell,nvim,Code
+```
+
+### Safe‑run & reconcile
+
+```bash
+./apply.sh --no       # dry run: show actions only
+./apply.sh --restow   # re-link after changes
+./apply.sh --delete   # unlink previously stowed files
+```
+
+> Tip: When files already exist, prefer **adopting** them into the repo, not clobbering. On macOS/Linux:
+
+```bash
+# Example: adopt existing ~/.zshrc into dotfiles/shell
+stow --adopt -t "$HOME" shell
+git add -A && git commit -m "Adopt shell configs"
+```
+
+---
+
+## 3) Update
 
 ```bash
 ./update.sh
 ```
 
-**Windows:**
+* Pulls latest changes and re‑applies.
+* Use on all platforms after you modify the repo elsewhere.
+
+Windows:
 
 ```powershell
 .\update.ps1
 ```
 
-Pulls latest changes from the repository and applies them using `--restow`.
+---
 
-## Common Operations
+## 4) VS Code extensions
 
-### 📦 **First install**
+List your desired extensions in `vscode_extensions.txt`. The scripts will install them on apply/update when supported.
 
-**Unix/Linux/macOS:**
+---
 
-```bash
-./init.sh
-```
+## 5) Adding a new package
 
-**Windows:**
+1. Create a folder: `dotfiles/<packageName>/`
+2. Inside it, mirror real paths (e.g., `dotfiles/foo/.config/foo/config.toml`)
+3. Test on one machine:
 
-```powershell
-.\init.ps1
-```
+   ```bash
+   ./apply.sh foo
+   ```
+4. Commit and push.
 
-### 🔍 **Preview changes**
+---
 
-**Unix/Linux/macOS:**
-
-```bash
-./apply.sh --no              # Dry-run, see what would happen
-./apply.sh --no --verbose    # Dry-run with detailed output
-```
-
-**Windows:**
-
-```powershell
-.\apply.ps1 --no             # Dry-run, see what would happen
-.\apply.ps1 --no --verbose   # Dry-run with detailed output
-```
-
-### 🔄 **Update existing**
-
-**Unix/Linux/macOS:**
+## 6) Uninstall / unlink
 
 ```bash
-./update.sh                  # Pull latest from repo and apply
-./apply.sh --restow          # Re-install everything
-./apply.sh                   # Normal stow (only new packages)
+./apply.sh --delete shell nvim
 ```
 
-**Windows:**
+---
 
-```powershell
-.\update.ps1                 # Pull latest from repo and apply
-.\apply.ps1 --restow         # Re-install everything
-.\apply.ps1                  # Normal stow (only new packages)
-```
+## 7) Windows symlink notes
 
-### ⚠️ **Handle conflicts**
+* With **Developer Mode** enabled, unprivileged symlinks work. Otherwise, run PowerShell as Administrator.
+* If a path is locked by another application, close it and retry.
+* Some Windows apps prefer config under `%APPDATA%` or `%LOCALAPPDATA%`; the package mirrors the destination.
 
-**Unix/Linux/macOS:**
+---
 
-```bash
-./apply.sh --adopt           # Take over existing files
-./apply.sh --no --adopt      # Preview what would be adopted
-```
+## 8) Conventions
 
-**Windows:**
+* Keep “secrets” in secure stores (e.g., 1Password, macOS Keychain, Windows Credential Manager). Don’t commit secrets.
+* Favor small, focused packages.
+* Re‑run `./apply.sh --restow` after renaming/moving files.
 
-```powershell
-.\apply.ps1 --adopt          # Take over existing files
-.\apply.ps1 --no --adopt     # Preview what would be adopted
-```
-
-### 🗑️ **Remove dotfiles**
-
-**Unix/Linux/macOS:**
-
-```bash
-./apply.sh --delete          # Remove all symlinks
-```
-
-**Windows:**
-
-```powershell
-.\apply.ps1 --delete         # Remove all symlinks
-```
-
-### 🎯 **Advanced operations**
-
-**Unix/Linux/macOS:**
-
-```bash
-./apply.sh --restow --verbose=2    # Verbose restow
-./apply.sh --ignore="*.log"        # Ignore log files
-./apply.sh --no --adopt --verbose  # Preview adoption with details
-```
-
-**Windows:**
-
-```powershell
-.\apply.ps1 --restow --verbose=2   # Verbose restow
-.\apply.ps1 --ignore="*.log"       # Ignore log files
-.\apply.ps1 --no --adopt --verbose # Preview adoption with details
-```
-
-## Stow Arguments Reference
-
-| Flag             | Description                 |
-| ---------------- | --------------------------- |
-| `--no`           | Dry-run (simulate only)     |
-| `--verbose`      | Show what's happening       |
-| `--adopt`        | Take over existing files    |
-| `--restow`       | Re-install (unlink + link)  |
-| `--delete`       | Remove symlinks             |
-| `--ignore=REGEX` | Skip files matching pattern |
-
-## Examples
-
-**Unix/Linux/macOS:**
-
-```bash
-# First time setup
-./init.sh
-
-# Update from remote repository
-./update.sh
-
-# See what would happen before adopting conflicts
-./apply.sh --no --adopt
-
-# Actually adopt conflicts
-./apply.sh --adopt
-
-# Update after local changes to dotfiles
-./apply.sh --restow
-
-# Remove everything
-./apply.sh --delete
-```
-
-**Windows:**
-
-```powershell
-# First time setup
-.\init.ps1
-
-# Update from remote repository
-.\update.ps1
-
-# See what would happen before adopting conflicts
-.\apply.ps1 --no --adopt
-
-# Actually adopt conflicts
-.\apply.ps1 --adopt
-
-# Update after local changes to dotfiles
-.\apply.ps1 --restow
-
-# Remove everything
-.\apply.ps1 --delete
-```

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,50 @@
+# CI / CD
+
+This repo uses GitHub Actions to validate **fresh installs**, **code quality**, **edge cases**, and **performance** across macOS, Linux, and Windows.
+
+## Workflows
+
+1) **comprehensive-test.yml** — Main testing pipeline  
+   - **Triggers:** push to main/develop, PRs, manual, weekly schedule  
+   - **Matrix:** Ubuntu (latest, 20.04), macOS (latest, 12), Windows (latest)  
+   - **Phases:** repository checks → dependency install (git, stow) → script runs (init/apply/update) → link verification → security & compliance
+
+2) **script-validation.yml** — Code quality  
+   - **ShellCheck** for `.sh`, PowerShell syntax validation for `.ps1`  
+   - Ensures parity between shell and PowerShell variants  
+   - Verifies README/docs match script behaviors where applicable
+
+3) **edge-case-testing.yml** — Stress & edge cases  
+   - Pre‑existing files & `--adopt` flow  
+   - Offline runs, rapid install/uninstall cycles  
+   - Concurrent operations and recovery from broken links
+
+4) **performance-monitoring.yml** — Speed & resource use  
+   - Track apply time, memory/IO, and regressions (e.g., via `hyperfine`)  
+   - Thresholds enforce steady performance
+
+## Coverage
+
+- **Platforms:** Linux (Ubuntu 20.04 + latest), macOS (12 + latest), Windows (latest)  
+- **Scripts:** `init.*`, `apply.*`, `update.*` (shell & PowerShell)  
+- **Packages:** common (shell, devtools, nvim, Code, kitty, lf) + macOS (hammerspoon) + Windows (Documents, vsvim, visual_studio, kinesis-advantage2, savant-elite2)
+
+## Quality gates & thresholds
+
+- All platform jobs pass
+- ShellCheck / PowerShell parse pass
+- No secrets or unsafe permissions detected
+- README/docs synced with actual package counts/flags
+- Performance within defined thresholds
+
+## Local equivalents
+
+```bash
+shellcheck *.sh
+AUTO_INSTALL=0 ./init.sh
+./apply.sh --no
+./apply.sh --restow
+./apply.sh --delete
+```
+
+Use `gh workflow run` to trigger workflows on-demand.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,16 @@
+# FAQ
+
+**Q: Does this overwrite my current files?**  
+By default, stow refuses to clobber. Use `--adopt` to bring files under management, or `--delete` to unlink previous symlinks.
+
+**Q: Can I use only part of the setup?**  
+Yes. Either edit `packages.txt` or pass package names to `apply`.
+
+**Q: How do I keep secrets out of Git?**  
+Never commit tokens/passwords. Use OS keychains/1Password; for configs that need secrets, source them from ignored files.
+
+**Q: How do I try changes safely?**  
+Work in a branch. Use `./apply.sh --no` to see effects, then `--restow` to apply.
+
+**Q: Why stow on Unix and PowerShell on Windows?**  
+It keeps platform ergonomics: stow is simple and ubiquitous on Unix; PowerShell gives precise control on Windows.

--- a/docs/keyboards.md
+++ b/docs/keyboards.md
@@ -1,0 +1,11 @@
+# Keyboards & Pedals (Windows)
+
+## Kinesis Advantage2
+- Layouts/macros kept under `dotfiles/kinesis-advantage2`.
+- Apply the package, then use Kinesis tools to load the layout if needed.
+
+## Savant Elite2 (foot pedal)
+- Config files under `dotfiles/savant-elite2`.
+- After applying, confirm the device picks up the profile.
+
+*Tip:* Keep device firmware/config files in Git even if you tweak them in vendor apps.

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -1,0 +1,23 @@
+# Packages
+
+> Default packages are read from `packages.txt`. You can override by passing names to `apply`.
+
+## Common
+- **shell:** ~/.zshrc, ~/.bashrc, gitconfig, aliases, prompt, etc.
+- **devtools:** CLI tools config (rg, fd, fzf, ripgrep aliases, etc.)
+- **nvim:** Neovim config (~/.config/nvim)
+- **Code:** VS Code user settings, keybindings, snippets
+- **kitty:** Kitty terminal (~/.config/kitty)
+- **lf:** lf file manager (~/.config/lf)
+
+## macOS
+- **hammerspoon:** Hammerspoon config (~/.hammerspoon)
+
+## Windows
+- **visual_studio:** VS settings
+- **vsvim:** VsVim settings
+- **kinesis-advantage2:** keyboard firmware/layouts/macros
+- **savant-elite2:** foot pedal config
+- **Documents:** convenience documents/configs that live under `~/Documents`
+
+*Note:* Exact file sets evolve; see the folders for the authoritative list.

--- a/docs/platform-notes.md
+++ b/docs/platform-notes.md
@@ -1,0 +1,18 @@
+# Platform Notes
+
+## macOS
+- Install Xcode CLT on first run if prompted.
+- Homebrew is used where appropriate; re-run `./init-macos.sh` after OS upgrades.
+- Hammerspoon is optional—disable the package if you don’t use it.
+
+## Linux
+- Use your distro’s package manager to install `git` and `stow` if the init script can’t.
+- Some desktop environments place configs under `~/.config`; follow the package mirrors.
+- Fonts: if your terminal/UI relies on Nerd Fonts, install one you like.
+
+## Windows
+- Enable **Developer Mode** (Settings → For Developers) to allow user symlinks.
+- Alternatively, run PowerShell **as Administrator**.
+- Visual Studio sometimes writes settings on exit; close VS before linking.
+- For per-user app data, configs often live in `%APPDATA%` or `%LOCALAPPDATA%`.
+

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,0 +1,24 @@
+# Repository Structure
+
+```
+
+dotfiles/
+shell/               # shells, gitconfig, aliases
+devtools/            # CLI tools (ripgrep, fd, fzf, etc.)
+nvim/                # Neovim config
+Code/                # VS Code settings/keybindings
+kitty/               # Kitty terminal
+lf/                  # lf file manager
+hammerspoon/         # macOS automation
+visual_studio/       # VS settings (Windows)
+vsvim/               # VsVim settings (Windows)
+kinesis-advantage2/  # keyboard firmware/layouts
+savant-elite2/       # foot pedal config
+
+```
+
+**Naming:** Each top‑level folder under `dotfiles/` is a **package**.  
+**Linking target:** By default we link into `$HOME` (or the equivalent on Windows).  
+**Why this layout?** It mirrors final paths so stow/PowerShell can place clean symlinks without custom logic.
+
+See **packages.md** for per‑package details.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,36 @@
+# Troubleshooting
+
+## “File already exists” / conflicts
+- Prefer adoption over clobbering:
+  ```bash
+  stow --adopt -t "$HOME" <package>
+  ```
+
+* Or explicitly unlink then restow:
+
+  ```bash
+  ./apply.sh --delete <package>
+  ./apply.sh <package>
+  ```
+
+## Windows: symlink permissions
+
+* Enable Developer Mode or run elevated PowerShell.
+* If a path is locked (e.g., by VS/Code), close the app first.
+
+## Neovim or Kitty not seeing a font/symbols
+
+* Install a Nerd Font and set it in your terminal emulator.
+* Restart terminal/editor after linking.
+
+## VS Code extensions didn’t install
+
+* Ensure `code` CLI is on PATH.
+* Re-run `./apply.sh Code` (or `\.\apply.ps1 -Packages Code`).
+
+## General sanity checks
+
+```bash
+./apply.sh --no          # dry-run to see actions
+stow -nvt "$HOME" <pkg>  # show what stow would do
+```

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -1,0 +1,9 @@
+# VS Code
+
+- Settings live under the `Code/` package.
+- Extensions: list them one per line in `vscode_extensions.txt`.
+- On apply/update, the script installs any missing extensions.
+
+Tips:
+- Sync is intentionally off; the repo is the source of truth.
+- Use project-specific `.vscode/` as needed; keep global defaults here.


### PR DESCRIPTION
## Summary
- rewrite README with concise cross-platform quick start and directory layout
- add README-usage plus docs for structure, packages, platform notes, VS Code, keyboards, CI, troubleshooting, and FAQ
- streamline AGENTS guidelines for automated environments

## Testing
- `./apply.sh --no`

------
https://chatgpt.com/codex/tasks/task_e_68accb52fd94832daafe3fcb1020eda4