### PR TITLE
fix: handle codelldb libs per OS

### DIFF
--- a/common/.config/nvim/lua/plugins/dap.lua
+++ b/common/.config/nvim/lua/plugins/dap.lua
@@ -83,7 +83,15 @@ return {
         if ok_pkg and codelldb:is_installed() then
           local ext = codelldb:get_install_path()
           local codelldb_path = ext .. "/extension/adapter/codelldb"
-          local liblldb_path = ext .. "/extension/lldb/lib/liblldb.dylib"
+          local sysname = vim.loop.os_uname().sysname
+          local liblldb_ext = "so"
+          if sysname:find("Windows") then
+            codelldb_path = codelldb_path .. ".exe"
+            liblldb_ext = "dll"
+          elseif sysname == "Darwin" then
+            liblldb_ext = "dylib"
+          end
+          local liblldb_path = ext .. "/extension/lldb/lib/liblldb." .. liblldb_ext
           dap.adapters.codelldb = function(cb, _)
             local stdout = vim.loop.new_pipe(false)
             local stderr = vim.loop.new_pipe(false)


### PR DESCRIPTION
## Summary
- fix codelldb adapter to detect platform-specific liblldb path and executable

## Testing
- `stylua common/.config/nvim/lua/plugins/dap.lua`
- `XDG_CONFIG_HOME=$PWD/common/.config nvim --headless -c "lua local dap=require('dap'); print(dap.adapters.codelldb and 'adapter set' or 'adapter missing')" -c 'qa'`
- `./apply.sh --no`
- `./apply.sh --no --adopt`
- `./apply.sh --no --restow`


------
https://chatgpt.com/codex/tasks/task_e_68bbacd0464c832db86724266c86289e