### PR TITLE
fix codelldb lookup in nvim dap setup

### DIFF
--- a/common/.config/nvim/lua/plugins/dap.lua
+++ b/common/.config/nvim/lua/plugins/dap.lua
@@ -79,7 +79,7 @@ return {
       -- mason-nvim-dap registers the adapter if installed, but we add robust fallback
       local ok_mason, mason_registry = pcall(require, "mason-registry")
       if ok_mason and not dap.adapters.codelldb then
-        local ok_pkg, codelldb = pcall(mason_registry.get_package, "codelldb")
+        local ok_pkg, codelldb = pcall(mason_registry.get_package, mason_registry, "codelldb")
         if ok_pkg and codelldb:is_installed() then
           local ext = codelldb:get_install_path()
           local codelldb_path = ext .. "/extension/adapter/codelldb"


### PR DESCRIPTION
## Summary
- fix codelldb package lookup when fallback-registering adapters in nvim DAP config

## Testing
- `./apply.sh --no`
- `./apply.sh --no --adopt`
- `./apply.sh --no --restow`
- `stylua common/.config/nvim/lua/plugins/dap.lua`
- `XDG_CONFIG_HOME=$PWD/common/.config nvim --headless '+lua local dap=require("dap"); print(type(dap))' +qa`
- `XDG_CONFIG_HOME=$PWD/common/.config nvim --headless '+lua local dap=require("dap"); print(dap.adapters.codelldb~=nil)' +qa`


------
https://chatgpt.com/codex/tasks/task_e_68bbb0287c6c832da996e811d214305a