### PR TITLE
Add smart st wrapper choosing ripgrep or Zoekt

### DIFF
--- a/common/.local/bin/st
+++ b/common/.local/bin/st
@@ -1,26 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Build args as an array so quoting stays correct.
-ADDITIONAL_ARGS=(--bind "enter:become(nvim +{2} {1})")
-
-if [[ "${1:-}" == "--code" ]]; then
-  # Open at line (and optionally column) without becoming; keep fzf running.
-  # If you want column too, use the commented line.
-  ADDITIONAL_ARGS=(
-    --bind "enter:execute-silent(code -r -g {1}:{2})"
-    --bind "esc:clear-query"
-    # --bind "enter:execute-silent(nvim '+call cursor({2},{3})' {1})"
-  )
+if [[ -d .zoekt ]]; then
+  exec st-zoekt "$@"
+else
+  exec st-rg "$@"
 fi
-
-exec fzf \
-  --ansi \
-  --disabled \
-  --tiebreak=index \
-  --bind "start:reload:rg --line-number --column --no-heading --color=always --smart-case {q} || true" \
-  --bind "change:reload:rg --line-number --column --no-heading --color=always --smart-case {q} || true" \
-  --delimiter : \
-  --preview 'bat --style=numbers --color=always --highlight-line {2} {1}' \
-  --preview-window 'bottom,30%,+{2}/2' \
-  "${ADDITIONAL_ARGS[@]}"

--- a/common/.local/bin/st-rg
+++ b/common/.local/bin/st-rg
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build args as an array so quoting stays correct.
+ADDITIONAL_ARGS=(--bind "enter:become(nvim +{2} {1})")
+
+if [[ "${1:-}" == "--code" ]]; then
+  # Open at line (and optionally column) without becoming; keep fzf running.
+  # If you want column too, use the commented line.
+  ADDITIONAL_ARGS=(
+    --bind "enter:execute-silent(code -r -g {1}:{2})"
+    --bind "esc:clear-query"
+    # --bind "enter:execute-silent(nvim '+call cursor({2},{3})' {1})"
+  )
+fi
+
+exec fzf \
+  --ansi \
+  --disabled \
+  --tiebreak=index \
+  --bind "start:reload:rg --line-number --column --no-heading --color=always --smart-case {q} || true" \
+  --bind "change:reload:rg --line-number --column --no-heading --color=always --smart-case {q} || true" \
+  --delimiter : \
+  --preview 'bat --style=numbers --color=always --highlight-line {2} {1}' \
+  --preview-window 'bottom,30%,+{2}/2' \
+  "${ADDITIONAL_ARGS[@]}"

--- a/common/.local/bin/st-zoekt
+++ b/common/.local/bin/st-zoekt
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# sz — Interactive search over a local Zoekt index with nice ripgrep-style coloring.
-# Usage: sz [--code] [PATH]
+# st-zoekt — Interactive search over a local Zoekt index with nice ripgrep-style coloring.
+# Usage: st-zoekt [--code] [PATH]
 #   --code   open matches in VS Code; default opens in nvim.
 #   PATH     directory or file within the tree; defaults to $PWD.
 # Requires: zoekt, fzf, ripgrep (for coloring), bat, nvim (or VS Code if --code).
@@ -42,7 +42,7 @@ reload_cmd="zoekt -index_dir '$index_dir' -- {q} | rg --passthru --color=always 
 
 # Fill the template root into ADDITIONAL_ARGS now that we know it
 for i in "${!ADDITIONAL_ARGS[@]}"; do
-  ADDITIONAL_ARGS[$i]="${ADDITIONAL_ARGS[$i]//\{root\}/$root}"
+  ADDITIONAL_ARGS[i]="${ADDITIONAL_ARGS[i]//\{root\}/$root}"
 done
 
 exec fzf \


### PR DESCRIPTION
## Summary
- rename original `st` ripgrep search to `st-rg`
- rename `sz` to `st-zoekt` and update its help text
- add `st` wrapper that dispatches to `st-zoekt` when a `.zoekt` index is present, otherwise `st-rg`

## Testing
- `./apply.sh --no`
- `./apply.sh --no --adopt`
- `./apply.sh --no --restow`
- `shellcheck common/.local/bin/st common/.local/bin/st-rg common/.local/bin/st-zoekt`


------
https://chatgpt.com/codex/tasks/task_e_68c77bc8a174832d82d01f9582b98045