### PR TITLE
Add global ignore for Zoekt artifacts

### DIFF
--- a/common/.config/git/config
+++ b/common/.config/git/config
@@ -9,6 +9,7 @@
 
 [core]
     pager = delta
+    excludesFile = ~/.config/git/ignore
 
 # --- Diff behavior ---
 [diff]

--- a/common/.config/git/ignore
+++ b/common/.config/git/ignore
@@ -1,0 +1,2 @@
+# Ignore generated Zoekt search indices
+**/.zoekt/


### PR DESCRIPTION
## Summary
- configure Git to use the global excludes file managed in the repo
- add an ignore pattern so generated `.zoekt` directories are skipped everywhere

## Testing
- ./apply.sh --no *(fails: stow: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8200b7d8832d89baef3d1ee5c3cd