### PR TITLE
Disable Snacks word highlighting in LazyVim

### DIFF
--- a/common/.config/nvim/lua/plugins/no-cursorword.lua
+++ b/common/.config/nvim/lua/plugins/no-cursorword.lua
@@ -1,0 +1,9 @@
+return {
+  -- Stop highlighting other occurrences of the word under the cursor
+  {
+    "folke/snacks.nvim",
+    opts = {
+      words = { enabled = false },
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- add a LazyVim plugin override that disables the Snacks words module so repeated cursor words are no longer highlighted

## Testing
- ./apply.sh --no *(fails: stow command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d080113100832da4c3955659ef434e