### PR TITLE
Add native renderer attach helper for Chromium

### DIFF
--- a/helpers/chrome/.vscode/launch.json
+++ b/helpers/chrome/.vscode/launch.json
@@ -51,6 +51,34 @@
         "script import lldbinit",
         "script import chromium_visualizers"
       ]
+    },
+    {
+      "name": "Chromium: Attach renderer by URL (CodeLLDB)",
+      "type": "lldb",
+      "request": "attach",
+      "pid": "${input:chromiumRendererPid}",
+      "preLaunchTask": "chromium: launch renderer for native attach",
+      "stopOnEntry": false,
+      "initCommands": [
+        "script sys.path[:0] = ['${workspaceFolder}/tools/lldb']",
+        "script import lldbinit",
+        "script import chromium_visualizers"
+      ],
+      "postRunCommands": [
+        "process signal SIGUSR1"
+      ]
+    }
+  ],
+  // Requires the Command Variable extension for reading the renderer PID file.
+  "inputs": [
+    {
+      "id": "chromiumRendererPid",
+      "type": "command",
+      "command": "extension.commandvariable.file.content",
+      "args": {
+        "fileName": "${config:chromium.rendererPidFile}",
+        "trim": true
+      }
     }
   ]
 }

--- a/helpers/chrome/.vscode/settings.json
+++ b/helpers/chrome/.vscode/settings.json
@@ -5,5 +5,10 @@
   "chromium.runtimeExecutable": "chrome",
   "chromium.runtimeExecutableMac": "Chromium.app/Contents/MacOS/Chromium",
   "chromium.runtimeExecutableLinux": "chrome",
-  "chromium.userDataDir": "${workspaceFolder}/.vscode/chrome-user-data"
+  "chromium.runtimeExecutableWindows": "chrome.exe",
+  "chromium.userDataDir": "${workspaceFolder}/.vscode/chrome-user-data",
+  "chromium.nativeUserDataDir": "${workspaceFolder}/.vscode/chrome-native-profile",
+  "chromium.nativeAttachUrl": "https://example.test/",
+  "chromium.rendererPidFile": "${workspaceFolder}/.vscode/.renderer_pid",
+  "chromium.rendererWaitTimeout": 120
 }

--- a/helpers/chrome/.vscode/tasks.json
+++ b/helpers/chrome/.vscode/tasks.json
@@ -78,6 +78,66 @@
         "clear": true
       },
       "problemMatcher": []
+    },
+    {
+      "label": "chromium: launch renderer for native attach",
+      "type": "shell",
+      "command": "${workspaceFolder}/tools/grab_renderer_pid.sh",
+      "args": [
+        "${config:chromium.nativeAttachUrl}",
+        "${config:chromium.rendererPidFile}",
+        "${config:chromium.nativeUserDataDir}"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "CHROME": "${workspaceFolder}/${config:chromium.buildDir}/${config:chromium.runtimeExecutable}",
+          "GRAB_RENDERER_TIMEOUT": "${config:chromium.rendererWaitTimeout}"
+        }
+      },
+      "osx": {
+        "options": {
+          "cwd": "${workspaceFolder}",
+          "env": {
+            "CHROME": "${workspaceFolder}/${config:chromium.buildDir}/${config:chromium.runtimeExecutableMac}",
+            "GRAB_RENDERER_TIMEOUT": "${config:chromium.rendererWaitTimeout}"
+          }
+        }
+      },
+      "linux": {
+        "options": {
+          "cwd": "${workspaceFolder}",
+          "env": {
+            "CHROME": "${workspaceFolder}/${config:chromium.buildDir}/${config:chromium.runtimeExecutableLinux}",
+            "GRAB_RENDERER_TIMEOUT": "${config:chromium.rendererWaitTimeout}"
+          }
+        }
+      },
+      "windows": {
+        "command": "powershell",
+        "args": [
+          "-NoProfile",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-File",
+          "${workspaceFolder}\\tools\\grab_renderer_pid.ps1",
+          "-Chrome",
+          "${workspaceFolder}\\${config:chromium.buildDir}\\${config:chromium.runtimeExecutableWindows}",
+          "-Url",
+          "${config:chromium.nativeAttachUrl}",
+          "-OutFile",
+          "${config:chromium.rendererPidFile}",
+          "-ProfileDir",
+          "${config:chromium.nativeUserDataDir}",
+          "-TimeoutSeconds",
+          "${config:chromium.rendererWaitTimeout}"
+        ]
+      },
+      "presentation": {
+        "panel": "dedicated",
+        "clear": true
+      },
+      "problemMatcher": []
     }
   ]
 }

--- a/helpers/chrome/tools/grab_renderer_pid.ps1
+++ b/helpers/chrome/tools/grab_renderer_pid.ps1
@@ -1,0 +1,67 @@
+param(
+  [string]$Chrome = "$PSScriptRoot/../out/Default/chrome.exe",
+  [string]$Url = "https://example.test/",
+  [string]$OutFile = ".vscode\.renderer_pid",
+  [string]$ProfileDir = ".vscode\chrome-native-profile",
+  [int]$TimeoutSeconds = 120
+)
+
+$OutParent = Split-Path -Parent $OutFile
+if (-not $OutParent) { $OutParent = "." }
+if ($OutParent) { New-Item -Force -ItemType Directory -Path $OutParent | Out-Null }
+$OutPath = Resolve-Path -LiteralPath $OutFile -ErrorAction SilentlyContinue
+if (-not $OutPath) {
+  New-Item -Force -ItemType File -Path $OutFile | Out-Null
+  $OutPath = Resolve-Path -LiteralPath $OutFile
+}
+
+$ProfilePath = Resolve-Path -LiteralPath $ProfileDir -ErrorAction SilentlyContinue
+if (-not $ProfilePath) {
+  New-Item -Force -ItemType Directory -Path $ProfileDir | Out-Null
+  $ProfilePath = Resolve-Path -LiteralPath $ProfileDir
+}
+
+$ChromePath = Resolve-Path -LiteralPath $Chrome -ErrorAction SilentlyContinue
+if (-not $ChromePath) {
+  throw "Chrome executable not found at $Chrome"
+}
+
+Set-Content -Path $OutPath.Path -Value ""
+
+$arguments = @(
+  "--user-data-dir=$($ProfilePath.Path)",
+  "--no-first-run",
+  "--no-default-browser-check",
+  "--renderer-process-limit=1",
+  "--wait-for-debugger-children=renderer",
+  "--enable-logging=stderr",
+  "--log-file=$($OutParent)\renderer-native.log",
+  $Url
+)
+
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = $ChromePath.Path
+$psi.Arguments = ($arguments -join ' ')
+$psi.UseShellExecute = $false
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $true
+$process = [System.Diagnostics.Process]::Start($psi)
+
+$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+$rendererPid = $null
+
+while ([DateTime]::UtcNow -lt $deadline) {
+  $children = Get-CimInstance Win32_Process | Where-Object { $_.ParentProcessId -eq $process.Id -and $_.CommandLine -like "*--type=renderer*" }
+  if ($children) {
+    $rendererPid = $children[0].ProcessId
+    break
+  }
+  Start-Sleep -Milliseconds 200
+}
+
+if (-not $rendererPid) {
+  $process.Kill()
+  throw "Timed out waiting for renderer"
+}
+
+Set-Content -Path $OutPath.Path -Value $rendererPid

--- a/helpers/chrome/tools/grab_renderer_pid.sh
+++ b/helpers/chrome/tools/grab_renderer_pid.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+URL="${1:-https://example.test/}"
+OUT_FILE="${2:-.vscode/.renderer_pid}"
+PROFILE_DIR="${3:-.vscode/chrome-native-profile}"
+CHROME_BIN="${CHROME:-${PWD}/out/Default/chrome}"
+TIMEOUT_SECONDS="${GRAB_RENDERER_TIMEOUT:-120}"
+
+if [[ ! -x "$CHROME_BIN" ]]; then
+  echo "error: chrome binary not found or not executable: $CHROME_BIN" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$OUT_FILE")" "$PROFILE_DIR"
+: > "$OUT_FILE"
+
+python3 - "$CHROME_BIN" "$URL" "$OUT_FILE" "$PROFILE_DIR" "$TIMEOUT_SECONDS" <<'PY'
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+chrome_bin, url, out_file, profile_dir, timeout_str = sys.argv[1:6]
+timeout = int(timeout_str)
+
+out_path = Path(out_file).resolve()
+profile_path = Path(profile_dir).resolve()
+
+log_dir = out_path.parent
+log_dir.mkdir(parents=True, exist_ok=True)
+log_file = log_dir / ".renderer_launch.log"
+
+unbuffer = None
+for candidate in ("unbuffer", "stdbuf"):
+    found = shutil.which(candidate)
+    if not found:
+        continue
+    if candidate == "stdbuf":
+        unbuffer = [found, "-oL", "-eL"]
+    else:
+        unbuffer = [found]
+    break
+
+cmd = []
+if unbuffer:
+    cmd.extend(unbuffer)
+cmd.extend([
+    str(chrome_bin),
+    f"--user-data-dir={profile_path}",
+    "--no-first-run",
+    "--no-default-browser-check",
+    "--allow-sandbox-debugging",
+    "--site-per-process",
+    "--wait-for-debugger-on-navigation",
+    "--enable-logging=stderr",
+    f"--log-file={log_file}",
+    url,
+])
+
+proc = subprocess.Popen(
+    cmd,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+    cwd=os.getcwd(),
+)
+
+pattern = re.compile(r'Renderer url="([^"]+)".*\(([0-9]+)\) paused waiting for debugger')
+start = time.time()
+released = set()
+
+handle = None
+offset = 0
+try:
+    while True:
+        if time.time() - start > timeout:
+            proc.terminate()
+            raise SystemExit(f"timed out waiting for renderer for {url}")
+        if handle is None:
+            if not log_file.exists():
+                time.sleep(0.1)
+                continue
+            handle = log_file.open('r', encoding='utf-8', errors='replace')
+        handle.seek(offset)
+        line = handle.readline()
+        if not line:
+            if proc.poll() is not None:
+                raise SystemExit(f"chrome exited before renderer for {url} was found")
+            time.sleep(0.1)
+            continue
+        offset = handle.tell()
+        match = pattern.search(line)
+        if not match:
+            continue
+        found_url, pid_str = match.group(1), match.group(2)
+        pid = int(pid_str)
+        if found_url == url:
+            out_path.write_text(f"{pid}\n", encoding='utf-8')
+            break
+        if pid not in released:
+            try:
+                os.kill(pid, signal.SIGUSR1)
+                released.add(pid)
+            except ProcessLookupError:
+                pass
+finally:
+    if handle is not None:
+        handle.close()
+
+sys.exit(0)
+PY


### PR DESCRIPTION
## Summary
- add renderer attach helper scripts for Chromium under `helpers/chrome/tools` to capture renderer PIDs on macOS/Linux and Windows
- wire VS Code launch/task configurations to run the helper, store the renderer PID, and resume the renderer after LLDB attach
- surface configuration settings for the native attach URL, profile directory, PID file, timeout, and Windows runtime binary

## Testing
- `./apply.sh --no` *(fails: stow not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d095b89cc0832dadff12ebcc0b9ba8