### PR TITLE
Fix st-rg bat preview arguments

### DIFF
--- a/common/.local/bin/st-rg
+++ b/common/.local/bin/st-rg
@@ -88,6 +88,6 @@ exec fzf \
   --with-nth=3.. \
   --bind "start:reload:${reload_cmd} || true" \
   --bind "change:reload:${reload_cmd} || true" \
-  --preview "cd '${root}' && bat --style=numbers --color=always {2} {1}" \
+  --preview "cd '${root}' && bat --style=numbers --color=always --highlight-line {2} -- {1}" \
   --preview-window 'bottom,30%,+{2}/2' \
   "${ADDITIONAL_ARGS[@]}"


### PR DESCRIPTION
## Summary
- update the st-rg fzf preview command to pass the line number to bat correctly
- highlight the target line while keeping other options unchanged

## Testing
- ./apply.sh --no *(fails: stow: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d0aba26628832d965982b58063e9d2