### PR TITLE
Fix bat preview invocation in search scripts

### DIFF
--- a/common/.local/bin/st-rg
+++ b/common/.local/bin/st-rg
@@ -88,6 +88,6 @@ exec fzf \
   --with-nth=3.. \
   --bind "start:reload:${reload_cmd} || true" \
   --bind "change:reload:${reload_cmd} || true" \
-  --preview "cd '${root}' && bat --style=numbers --color=always {2} {1}" \
+  --preview "cd '${root}' && if [ -n '{2}' ]; then bat --style=numbers --color=always --line-range {2}: -- {1}; else bat --style=numbers --color=always -- {1}; fi" \
   --preview-window 'bottom,30%,+{2}/2' \
   "${ADDITIONAL_ARGS[@]}"

--- a/common/.local/bin/st-zoekt
+++ b/common/.local/bin/st-zoekt
@@ -92,6 +92,6 @@ exec fzf \
   --with-nth=3.. \
   --bind "start:reload:${reload_cmd} || true" \
   --bind "change:reload:${reload_cmd} || true" \
-  --preview "cd '${root}' && bat --style=numbers --color=always {2} {1}" \
+  --preview "cd '${root}' && if [ -n '{2}' ]; then bat --style=numbers --color=always --line-range {2}: -- {1}; else bat --style=numbers --color=always -- {1}; fi" \
   --preview-window 'bottom,30%,+{2}/2' \
   "${ADDITIONAL_ARGS[@]}"


### PR DESCRIPTION
## Summary
- ensure st-rg and st-zoekt pass the matched line to bat using --line-range
- guard previews so they still work when no line number is available

## Testing
- ./apply.sh --no *(fails: stow: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d0aba26628832d965982b58063e9d2