### PR TITLE
Bind y to copy selection in tmux copy mode

### DIFF
--- a/common/.tmux.conf
+++ b/common/.tmux.conf
@@ -39,6 +39,10 @@ set-option -g set-clipboard on
 # Use VIM bindings
 setw -g mode-keys vi
 
+# Copy selection with "y" in copy mode (same as Enter)
+bind-key -T copy-mode-vi y send -X copy-selection-and-cancel
+bind-key -T copy-mode    y send -X copy-selection-and-cancel
+
 # Vim bindings for navigation
 bind-key h select-pane -L
 bind-key j select-pane -D


### PR DESCRIPTION
## Summary
- bind `y` in tmux copy mode to copy the selection and exit, mirroring the Enter key behavior

## Testing
- ./apply.sh --no *(fails: `stow` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d05243a4832d9b484256769e2f46