### PR TITLE
Limit Shift+F4/F6 tmux bindings to copy mode

### DIFF
--- a/common/.tmux.conf
+++ b/common/.tmux.conf
@@ -49,6 +49,12 @@ bind-key j select-pane -D
 bind-key k select-pane -U
 bind-key l select-pane -R
 
+# Scroll 16 lines at a time (matches VS Code Shift+F4/Shift+F6 macros) while in copy mode
+bind-key -T copy-mode-vi S-F4 send-keys -X -N 16 scroll-up
+bind-key -T copy-mode-vi S-F6 send-keys -X -N 16 scroll-down
+bind-key -T copy-mode S-F4 send-keys -X -N 16 scroll-up
+bind-key -T copy-mode S-F6 send-keys -X -N 16 scroll-down
+
 # after your prefix declaration
 # bind-key l next-window
 # bind-key h previous-window


### PR DESCRIPTION
## Summary
- restrict the Shift+F4/F6 tmux key bindings to the copy-mode key tables so the shortcuts only work after entering copy mode

## Testing
- ./apply.sh --no *(fails: stow: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9221427c832d8fa8695127a69cc3