### PR TITLE
Show timestamps in shell prompt and tmux status

### DIFF
--- a/common/.config/starship.toml
+++ b/common/.config/starship.toml
@@ -5,7 +5,7 @@
 add_newline = true
 command_timeout = 1000
 format = """
-$all$fill${custom.time_stamp}
+$all$fill$time
 $character"""
 
 [fill]
@@ -28,27 +28,8 @@ show_milliseconds = true
 disabled = true
 
 [time]
-disabled = true
-
-[custom.time_stamp]
-command = '''
-CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}"
-STATE_FILE="$CACHE_DIR/starship-last-command-time"
-mkdir -p "$CACHE_DIR"
-CURRENT="$(date "+%-I:%M %p")"
-PREVIOUS=""
-if [ -r "$STATE_FILE" ]; then
-  read -r PREVIOUS < "$STATE_FILE"
-fi
-
-if [ "$CURRENT" != "$PREVIOUS" ]; then
-  printf "%s" "$CURRENT" > "$STATE_FILE.tmp"
-  mv "$STATE_FILE.tmp" "$STATE_FILE"
-  printf "%s" "$CURRENT"
-fi
-:
-'''
-format = '[$output ]($style)'
+format = '[$time ]($style)'
+time_format = "%-I:%M %p"
 style = 'fg:#5c7080 dimmed'
 
 [git_branch]


### PR DESCRIPTION
## Summary
- enable the starship time module so each prompt includes the current timestamp
- extend the tmux status bar to display the host name and current date/time

## Testing
- ./apply.sh --no *(fails: stow: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5495a09a0832da52c8ba026575f42