### PR TITLE
Refine prompt time placement and tmux clock styling

### DIFF
--- a/common/.config/starship.toml
+++ b/common/.config/starship.toml
@@ -4,6 +4,7 @@
 # Inserts a blank line between shell prompts
 add_newline = true
 command_timeout = 1000
+right_format = "$time"
 
 # Replace the '❯' symbol in the prompt with '➜'
 [character] # The name of the module we are configuring is 'character'
@@ -17,6 +18,12 @@ disabled = true
 [cmd_duration]
 min_time = 1000
 show_milliseconds = true
+
+[time]
+disabled = false
+format = '[$time]($style)'
+style = 'fg:#4c566a'
+time_format = '%H:%M:%S'
 
 [git_branch]
 disabled = true

--- a/common/.tmux.conf
+++ b/common/.tmux.conf
@@ -77,7 +77,7 @@ set -g status-fg        '#516e7b'
 set -g status-left-length  30
 set -g status-right-length 80
 set -g status-left  "#[bg=#1a1b26,fg=#3C425F] #S  "
-set -g status-right "#[fg=#3C425F]#(hostname) "
+set -g status-right "#[fg=#3C425F]#(hostname) #[fg=#516e7b]%I:%M %p "
 
 setw -g window-status-current-format "#[fg=#88c0d0]#[fg=#88c0d0,bg=#516e7b]#[reverse]#I #[fg=#88c0d0,bg=#1a1b26]#W#[default]#[fg=#88c0d0]"
 # set -g status-justify centre


### PR DESCRIPTION
## Summary
- move the starship time module to the right prompt so it sits alongside the directory and dim its color
- switch the tmux status clock to a dimmer 12-hour time display without the date

## Testing
- ./apply.sh --no *(fails: stow: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5495a09a0832da52c8ba026575f42