### PR TITLE
Fix macOS LazyGit diff preview config

### DIFF
--- a/common/.config/lazygit/config.yml
+++ b/common/.config/lazygit/config.yml
@@ -1,8 +1,15 @@
 git:
+  # Support both current and older LazyGit config schemas.
+  paging:
+    colorArg: always # Delta wants colored input; LazyGit handles paging itself.
+    pager: >-
+      delta --dark --paging=never --hyperlinks
+      --hyperlinks-file-link-format="lazygit-edit://{path}:{line}"
   pagers:
-    - # Delta wants colored input; LazyGit handles paging itself
-      colorArg: always # recommended for delta as a pager
-      pager: delta --dark --paging=never \ --hyperlinks --hyperlinks-file-link-format="lazygit-edit://{path}:{line}"
+    - colorArg: always
+      pager: >-
+        delta --dark --paging=never --hyperlinks
+        --hyperlinks-file-link-format="lazygit-edit://{path}:{line}"
   parseEmoji: false
 promptToReturnFromSubprocess: false
 promptToOpenMergeTool: false


### PR DESCRIPTION
## Summary
- update the LazyGit pager config to support both current `git.paging` and legacy `git.pagers` schemas
- normalize the `delta` pager command formatting so hyperlink arguments are passed correctly
- preserve the existing styled diff behavior across macOS and other platforms

## Testing
- `./apply.sh --no`
- `./apply.sh --no --restow`