### PR TITLE
yazi: add `gy` keymap shortcut for local yazi config

### DIFF
--- a/common/.config/yazi/keymap.toml
+++ b/common/.config/yazi/keymap.toml
@@ -253,6 +253,11 @@ run = "cd ~/.config"
 desc = "Go to Config"
 
 [[mgr.prepend_keymap]]
+on = [ "g", "y" ]
+run = "cd ~/.config/yazi-local"
+desc = "Go to local Yazi config"
+
+[[mgr.prepend_keymap]]
 on = [ "g", "s" ]
 run = "cd ~/chrome/src"
 desc = "Go to Chrome src"


### PR DESCRIPTION
### Motivation
- Provide a quick Yazi shortcut to open the machine-local Yazi config directory at `~/.config/yazi-local` using the existing `g`-prefix navigation style.

### Description
- Added a new `[[mgr.prepend_keymap]]` block in `common/.config/yazi/keymap.toml` with `on = [ "g", "y" ]`, `run = "cd ~/.config/yazi-local"`, and `desc = "Go to local Yazi config"`.

### Testing
- Ran `./apply.sh --no` which performed a dry-run but failed in this environment because `stow` is not installed (`stow: command not found`).
- Ran `./apply.sh --no --restow` which also failed for the same reason.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1283f51f0832d892fed184abc24ad)