### PR TITLE
starship: show cloud workspace segment in prompt

### DIFF
--- a/common/.config/starship.toml
+++ b/common/.config/starship.toml
@@ -4,7 +4,7 @@
 # Inserts a blank line between shell prompts
 add_newline = true
 command_timeout = 1000
-format = "$username$hostname${custom.git_workspace}$directory$git_branch${custom.git_cl}$git_commit$git_state$git_status$cmd_duration\n$character"
+format = "$username$hostname${custom.cloud_workspace}${custom.git_workspace}$directory$git_branch${custom.git_cl}$git_commit$git_state$git_status$cmd_duration\n$character"
 right_format = "$time"
 
 [fill]
@@ -58,6 +58,13 @@ disabled = true
 
 [rust]
 disabled = true
+
+[custom.cloud_workspace]
+description = "Cloud workspace name"
+when = 'echo "$PWD" | grep -q "^/google/src/cloud/[^/]*/[^/]*"'
+command = 'echo "$PWD" | cut -d/ -f6'
+format = '[$output]($style) '
+style = 'bold #af87ff'
 
 [custom.git_workspace]
 description = "Chromium workspace name (chrome/chrome2/etc)"


### PR DESCRIPTION
### Motivation
- Show the current cloud workspace name in the prompt when inside Google cloud workspaces so developers can immediately identify which cloud workspace they are in.

### Description
- Updated `common/.config/starship.toml` prompt `format` to include `${custom.cloud_workspace}` before `${custom.git_workspace}`.
- Added a new `[custom.cloud_workspace]` module that activates when `PWD` matches `/google/src/cloud/<workspace>/<repo>`, extracts the workspace name with a shell command, and renders it in `bold #af87ff`.

### Testing
- Ran `./apply.sh --no` as a dry-run which reached the `stow` invocation and failed in this environment with `stow: command not found`.
- Ran `./apply.sh --no --adopt` as a dry-run which reached the `stow` invocation and failed with `stow: command not found`.
- Ran `./apply.sh --no --restow` as a dry-run which reached the `stow` invocation and failed with `stow: command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e12a3ac6bc832daf166036f50951d3)