### PR TITLE
Add Linux lazyjj installer and init hook

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -105,6 +105,17 @@ if [ -f "install-nvim.sh" ] && [[ "$(uname)" == "Linux" ]]; then
   fi
 fi
 
+# Optional: Install lazyjj (Linux only)
+if [ -f "install-lazyjj.sh" ] && [[ "$(uname)" == "Linux" ]]; then
+  install_lazyjj=$(get_user_confirmation "Install lazyjj (Rust jj TUI)? (y/N): ")
+  if [[ "$install_lazyjj" =~ ^[Yy] ]]; then
+    echo "Running lazyjj installation script..."
+    ./install-lazyjj.sh
+  else
+    echo "Skipping lazyjj installation"
+  fi
+fi
+
 # Optional: Install Yazi with enhanced features (GitHub binary for Linux)
 if [ -f "install-yazi.sh" ]; then
   install_yazi=$(get_user_confirmation "Install Yazi (may prompt again for install method)? (y/N): ")

--- a/install-lazyjj.sh
+++ b/install-lazyjj.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname)" != "Linux" ]]; then
+  echo "install-lazyjj.sh currently supports Linux hosts only."
+  exit 0
+fi
+
+if ! command -v cargo >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+error: cargo is required to install lazyjj.
+Install Rust (https://rustup.rs/) and re-run this script.
+EOF
+  exit 1
+fi
+
+version_spec="${LAZYJJ_VERSION:-latest}"
+
+echo "Installing lazyjj (${version_spec})..."
+if [[ "$version_spec" == "latest" ]]; then
+  cargo install --locked --force lazyjj
+else
+  cargo install --locked --force --version "$version_spec" lazyjj
+fi
+
+if command -v lazyjj >/dev/null 2>&1; then
+  echo "✅ lazyjj installed: $(lazyjj --version)"
+else
+  echo "⚠️ lazyjj installed, but it is not on PATH yet."
+  echo "   Add ~/.cargo/bin to PATH and restart your shell."
+fi


### PR DESCRIPTION
### Motivation
- Provide a reusable, separate installer for the Rust-based `lazyjj` jj-compatible TUI and integrate it into the existing Linux init flow.
- Match the repo's pattern of separate optional installer scripts (like `install-nvim.sh`, `install-yazi.sh`) so installers are discoverable and optional during `./init.sh`.

### Description
- Added `install-lazyjj.sh`, a Linux-only installer that requires `cargo`, supports pinning with the `LAZYJJ_VERSION` environment variable, installs via `cargo install --locked --force`, and prints PATH guidance if `~/.cargo/bin` is not on `PATH`.
- Updated `init.sh` to prompt `Install lazyjj (Rust jj TUI)? (y/N):` on Linux and run `./install-lazyjj.sh` when accepted.
- Affected files: `install-lazyjj.sh` (new) and `init.sh` (modified).

### Testing
- Ran syntax checks with `bash -n init.sh install-lazyjj.sh`, which completed successfully.
- Attempted to run `shellcheck init.sh install-lazyjj.sh` but `shellcheck` was not available in the environment so it was skipped.
- Ran stow dry-run flows `./apply.sh --no`, `./apply.sh --no --adopt`, and `./apply.sh --no --restow` but these stopped due to `stow: command not found` in the environment, so a full dry-run install could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e68fb0fc98832d891b6b539a8f1747)