### PR TITLE
Enhance zsh command help and completion behavior

### DIFF
--- a/common/.zshrc
+++ b/common/.zshrc
@@ -30,6 +30,11 @@ autoload -Uz edit-command-line
 zle -N edit-command-line
 bindkey '^X' edit-command-line          # Ctrl+X edits current prompt
 
+# -------- help on current command (Esc h)
+unalias run-help 2>/dev/null
+autoload -Uz run-help
+bindkey '^[h' run-help
+
 # -------- completion (cached)
 # Cache to XDG location and compile the dump for speed.
 zmodload -i zsh/complist
@@ -52,7 +57,9 @@ if [[ -s $_compdump && ( ! -s $_compdump.zwc || $_compdump -nt $_compdump.zwc ) 
 fi
 unset _compdump
 
+zstyle ':completion:*' verbose yes
 zstyle ':completion:*' menu select
+zstyle ':completion:*:descriptions' format '%F{yellow}-- %d --%f'
 zstyle ':completion:*' matcher-list 'm:{a-z}={A-Za-z}'
 
 # # -------- prompt (Starship)
@@ -95,6 +102,79 @@ if ((! $+commands[delta] )) || ((! $+commands[code] )); then
     command git "${cfg[@]}" "$@"
   }
 fi
+
+# -------- show --help for command in current buffer (Ctrl-X h)
+show-help-for-buffer() {
+  emulate -L zsh
+
+  local -a words helpcmd
+  words=(${(z)BUFFER})
+
+  while (( $#words )); do
+    case "${words[1]}" in
+      sudo|command|exec|noglob|time)
+        shift words
+        ;;
+      env)
+        shift words
+        while (( $#words )) && [[ "${words[1]}" == *=* ]]; do
+          shift words
+        done
+        ;;
+      *=*)
+        shift words
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+
+  if (( $#words == 0 )); then
+    zle -M "No command found"
+    return
+  fi
+
+  local cmd="${words[1]}"
+  helpcmd=("$cmd")
+
+  case "$cmd" in
+    git|docker|kubectl|cargo|npm|pnpm|yarn|go|gh|brew)
+      shift words
+      local w
+      for w in "${words[@]}"; do
+        case "$w" in
+          -*|">"|"<"|"|"|"&&"|"||"|";")
+            break
+            ;;
+          *)
+            helpcmd+=("$w")
+            ;;
+        esac
+        (( $#helpcmd >= 3 )) && break
+      done
+      ;;
+  esac
+
+  local tmp
+  tmp="$(mktemp "${TMPDIR:-/tmp}/zsh-help.XXXXXX")" || return
+
+  zle -I
+
+  "${helpcmd[@]}" --help >"$tmp" 2>&1
+
+  if [[ -s "$tmp" ]]; then
+    less -R "$tmp"
+  else
+    man "$cmd" 2>/dev/null
+  fi
+
+  rm -f "$tmp"
+  zle reset-prompt
+}
+
+zle -N show-help-for-buffer
+bindkey '^Xh' show-help-for-buffer
 
 # -------- aliases
 alias grep='grep --color=auto'


### PR DESCRIPTION
### Motivation
- Improve in-shell command help and make option discovery more ergonomic by preferring completion metadata over repeatedly running `--help`.
- Provide a quick built-in help key and an explicit widget to run `--help` when users want the raw program output.
- Make completion menus more informative so users can see option descriptions during tab completion.

### Description
- Updated `common/.zshrc` to initialize `run-help` and bind `Esc h` for contextual command help using the built-in mechanism. 
- Added completion UI styles via `zstyle` to enable verbose descriptions and formatted group labels for the completion system. 
- Added a `show-help-for-buffer` ZLE widget that runs the current buffer's command with `--help` (handles common wrappers and common subcommands) and bound it to `Ctrl-X h`. 
- Target file: `common/.zshrc` (changes are limited to completion/help initialization and the new widget).

### Testing
- Ran dry-run apply preview `./apply.sh --no` which executed a preview but failed due to missing `stow` (`stow: command not found`).
- Ran dry-run restow preview `./apply.sh --no --restow` which also failed for the same reason (`stow: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a72af9d8832db165881596e29270)