### PR TITLE
Add tmux status naming helper

### DIFF
--- a/common/.local/bin/tmux-status-name.sh
+++ b/common/.local/bin/tmux-status-name.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Get the current path and command from arguments
+current_path="$1"
+current_command="$2"
+
+workspace=""
+
+if [[ "$current_path" =~ ^/google/src/cloud/[^/]+/([^/]+) ]]; then
+  workspace="${BASH_REMATCH[1]}"
+fi
+
+# 2. Detect Git workspace
+if [ -z "$workspace" ]; then
+  git_dir=$(git -C "$current_path" rev-parse --show-toplevel 2>/dev/null)
+  if [ -n "$git_dir" ]; then
+    workspace=$(basename "$git_dir")
+  fi
+fi
+
+# 3. Fallback to current directory name
+if [ -z "$workspace" ]; then
+  workspace=$(basename "$current_path")
+fi
+
+# Process command
+cmd="$current_command"
+# Ignore common shells
+if [[ "$cmd" =~ ^(bash|zsh|fish)$ ]]; then
+  cmd=""
+fi
+
+# Output the result
+if [ -n "$cmd" ]; then
+  echo "${workspace}:${cmd}"
+else
+  echo "${workspace}"
+fi

--- a/common/.tmux.conf
+++ b/common/.tmux.conf
@@ -115,8 +115,7 @@ setw -g window-status-current-format "#[fg=#88c0d0]#[fg=#88c0d0,bg=#516e7b]#[
 # current directory, while other programs keep their command name.
 set-option -g allow-rename off
 set-window-option -g automatic-rename on
-set-window-option -g automatic-rename-format \
-  '#{?#{||:#{||:#{==:#{pane_current_command},zsh},#{==:#{pane_current_command},bash}},#{==:#{pane_current_command},fish}},#{b:pane_current_path},#{b:pane_current_command}}'
+set-window-option -g automatic-rename-format '#(~/.local/bin/tmux-status-name.sh "#{pane_current_path}" "#{pane_current_command}")'
 
 # Remove flags for inactive windows
 set-option -g window-status-format " #[fg=#3C425F]#I #[fg=#88c0d0]#W "

--- a/common/.zshrc
+++ b/common/.zshrc
@@ -189,3 +189,6 @@ unset -f _source_zsh_plugin
 # -------- machine-specific overrides
 # shellcheck disable=SC1090
 [[ -r "$HOME/.zshrc.local" ]] && source "$HOME/.zshrc.local"
+
+# Dynamic Tmux Title
+[[ -f ~/.local/bin/tmux-title.zsh ]] && source ~/.local/bin/tmux-title.zsh


### PR DESCRIPTION
### Motivation
- Make tmux automatic window names more meaningful by showing a workspace name (Google Cloud workspace or Git root) and appending the active non-shell command when appropriate.

### Description
- Add executable helper `common/.local/bin/tmux-status-name.sh` that derives a workspace name from a Google Cloud path, falls back to the Git repository root, and finally the current directory, and omits common shells when appending the pane command.
- Update `common/.tmux.conf` to call the helper via `set-window-option -g automatic-rename-format '#(~/.local/bin/tmux-status-name.sh "#{pane_current_path}" "#{pane_current_command}")'` for automatic window naming.
- Update `common/.zshrc` to source an optional hook at `~/.local/bin/tmux-title.zsh` if present.
- Ensure the new script is installed as an executable (`100755`).

### Testing
- Ran `shellcheck common/.local/bin/tmux-status-name.sh` and it completed successfully.
- Ran the required stow dry-run checks with `./apply.sh --no` and the dry-run completed successfully.
- Ran the adoption preview `./apply.sh --no --adopt` and the restow preview `./apply.sh --no --restow`, both of which completed successfully in dry-run mode.
- Installed `stow` and `shellcheck` in the environment to allow the above checks to run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fea6c025bc832d9ae4034a1ba6a14f)