### PR TITLE
Add fuzzy tmux session switcher

### DIFF
--- a/common/.local/bin/tmux-fzf-switch-session
+++ b/common/.local/bin/tmux-fzf-switch-session
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -eu
+
+if ! command -v fzf >/dev/null 2>&1; then
+  tmux display-message 'fzf is required for fuzzy session switching'
+  exit 1
+fi
+
+selected=$(
+  tmux list-sessions -F '#{session_activity}|#{session_name}|#{session_windows} windows|#{?session_attached,attached,detached}' |
+    sort -rn -t'|' -k1,1 |
+    cut -d'|' -f2- |
+    fzf \
+      --delimiter='|' \
+      --with-nth=1,2,3 \
+      --prompt='session> ' \
+      --header='enter: switch  ctrl-r: refresh  esc: cancel' \
+      --preview='tmux list-windows -t {1} -F "#{window_index}: #{window_name} (#{window_panes} panes) #{?window_active,*, }#{pane_current_path}"' \
+      --preview-window='right:60%:wrap' \
+      --bind='ctrl-r:reload(tmux list-sessions -F "#{session_activity}|#{session_name}|#{session_windows} windows|#{?session_attached,attached,detached}" | sort -rn -t"|" -k1,1 | cut -d"|" -f2-)' |
+    cut -d'|' -f1
+)
+
+[ -n "$selected" ] && tmux switch-client -t "$selected"

--- a/common/.tmux.conf
+++ b/common/.tmux.conf
@@ -79,6 +79,9 @@ bind-key -r '<' run-shell 'id=$(tmux display -p "#{window_id}"); tmux swap-windo
 bind-key -r '>' run-shell 'id=$(tmux display -p "#{window_id}"); tmux swap-window -t:+1; tmux select-window -t "$id"'
 bind-key C new-window -a -c "#{pane_current_path}"
 
+# Fuzzy session switcher: prefix + s (matches tmux's standard session key)
+bind-key s display-popup -E -w 85% -h 75% '~/.local/bin/tmux-fzf-switch-session'
+
 # after your prefix declaration
 # bind-key l next-window
 # bind-key h previous-window


### PR DESCRIPTION
### Motivation
- Provide a quick, single-key (lowercase) fuzzy session switcher for tmux using `fzf` so sessions can be chosen with a popup and preview. 
- Use a sensible default key that aligns with tmux conventions (`prefix + s`) and offer a preview + refresh while selecting. 

### Description
- Add `common/.local/bin/tmux-fzf-switch-session`, an executable helper that verifies `fzf` is present, lists sessions ordered by recent activity, and invokes `fzf` with a right-side preview of each session's windows; pressing Enter switches to the chosen session. 
- Add a tmux binding in `common/.tmux.conf` that maps `prefix + s` to open an `85%x75%` popup that runs the helper script. 
- The helper uses `tmux list-sessions -F` formatting, `fzf` options `--with-nth`, `--preview`, and `--bind=ctrl-r:reload` to support refresh and clear previewing. 
- The helper is installed under the common package so it will be stowed into `~/.local/bin` and is executable. 

### Testing
- Ran `sh -n common/.local/bin/tmux-fzf-switch-session` to validate shell syntax: succeeded. 
- Sourced the modified tmux config in isolated tmux servers and verified the binding exists via `tmux -L ... source-file` and `tmux -L ... list-keys -T prefix s`: succeeded. 
- Ran repository apply/restow previews via `./apply.sh --no`, `./apply.sh --no --adopt`, and `./apply.sh --no --restow` (dry-run): all succeeded. 
- Attempted to run `shellcheck` on the helper but `shellcheck` is not installed in this environment, so that lint check was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01395245f4832db1beca381fcf1587)