### PR TITLE
Preview tmux session windows in fzf

### DIFF
--- a/common/.local/bin/tmux-fzf-session-preview
+++ b/common/.local/bin/tmux-fzf-session-preview
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+set -eu
+
+session=${1:-}
+[ -n "$session" ] || exit 0
+
+# Build an fzf preview that mirrors tmux's tree chooser context: show every
+# window in the selected session, plus a small capture from each active pane.
+tmux list-windows -t "$session" -F '#{window_index}|#{window_name}|#{window_panes}|#{?window_active,*, }|#{pane_current_command}|#{pane_current_path}' |
+while IFS='|' read -r index name panes active command path; do
+  if [ "$active" = '*' ]; then
+    marker='*'
+  else
+    marker=' '
+  fi
+
+  printf '%s %s: %s (%s panes) - %s\n' "$marker" "$index" "$name" "$panes" "$command"
+  printf '  %s\n' "$path"
+  printf '%s\n' '────────────────────────────────────────'
+
+  # Capture the visible area from the active pane in each window. Limit the
+  # amount of text so sessions with many windows keep the preview responsive.
+  tmux capture-pane -e -p -t "$session:$index" -S -12 2>/dev/null | sed -e 's/^/  /' || true
+  printf '\n'
+done

--- a/common/.local/bin/tmux-fzf-switch-session
+++ b/common/.local/bin/tmux-fzf-switch-session
@@ -15,7 +15,7 @@ selected=$(
       --with-nth=1,2,3 \
       --prompt='session> ' \
       --header='enter: switch  ctrl-r: refresh  esc: cancel' \
-      --preview='tmux list-windows -t {1} -F "#{window_index}: #{window_name} (#{window_panes} panes) #{?window_active,*, }#{pane_current_path}"' \
+      --preview='~/.local/bin/tmux-fzf-session-preview {1}' \
       --preview-window='right:60%:wrap' \
       --bind='ctrl-r:reload(tmux list-sessions -F "#{session_activity}|#{session_name}|#{session_windows} windows|#{?session_attached,attached,detached}" | sort -rn -t"|" -k1,1 | cut -d"|" -f2-)' |
     cut -d'|' -f1

--- a/common/.tmux.conf
+++ b/common/.tmux.conf
@@ -79,8 +79,9 @@ bind-key -r '<' run-shell 'id=$(tmux display -p "#{window_id}"); tmux swap-windo
 bind-key -r '>' run-shell 'id=$(tmux display -p "#{window_id}"); tmux swap-window -t:+1; tmux select-window -t "$id"'
 bind-key C new-window -a -c "#{pane_current_path}"
 
-# Fuzzy session switcher: prefix + s (matches tmux's standard session key)
+# Fuzzy session switcher: prefix + s/S (matches tmux's standard session key)
 bind-key s display-popup -E -w 85% -h 75% '~/.local/bin/tmux-fzf-switch-session'
+bind-key S display-popup -E -w 85% -h 75% '~/.local/bin/tmux-fzf-switch-session'
 
 # after your prefix declaration
 # bind-key l next-window


### PR DESCRIPTION
### Motivation
- Improve the session chooser so selecting a session shows a preview of all its windows, mirroring tmux's built-in session chooser behavior. 
- Provide useful context for each window by including window metadata and recent visible output from the active pane to make session selection more informed.

### Description
- Add `common/.local/bin/tmux-fzf-session-preview`, a helper that lists every window in a session, marks the active window, prints pane/path/command metadata, and captures the last visible lines from each window's active pane. 
- Update `common/.local/bin/tmux-fzf-switch-session` to use the new preview helper via `--preview='~/.local/bin/tmux-fzf-session-preview {1}'` for the fzf popup. 
- Update `common/.tmux.conf` to bind both `prefix+s` and `prefix+S` to open the fuzzy session chooser popup (`~/.local/bin/tmux-fzf-switch-session`).

### Testing
- Ran syntax check of the switcher script with `sh -n common/.local/bin/tmux-fzf-switch-session common/.local/bin/tmux-fzf-session-preview` and it succeeded. 
- Ran `shellcheck common/.local/bin/tmux-fzf-switch-session common/.local/bin/tmux-fzf-session-preview` and it reported no blocking issues. 
- Performed dotfiles dry-run installs with `./apply.sh --no`, `./apply.sh --no --adopt`, and `./apply.sh --no --restow`, all of which completed successfully in simulation mode. 
- Created a temporary tmux session with two windows and ran `common/.local/bin/tmux-fzf-session-preview <session>` to validate preview output, which displayed window metadata and captured pane output as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01d6da82c4832da645c48361f8b24b)