### PR TITLE
Remove tmux prefix-s shortcut

### DIFF
--- a/common/.tmux.conf
+++ b/common/.tmux.conf
@@ -79,9 +79,6 @@ bind-key -r '<' run-shell 'id=$(tmux display -p "#{window_id}"); tmux swap-windo
 bind-key -r '>' run-shell 'id=$(tmux display -p "#{window_id}"); tmux swap-window -t:+1; tmux select-window -t "$id"'
 bind-key C new-window -a -c "#{pane_current_path}"
 
-# Fuzzy session switcher: prefix + s (matches tmux's standard session key)
-bind-key s display-popup -E -w 85% -h 75% '~/.local/bin/tmux-fzf-switch-session'
-
 # after your prefix declaration
 # bind-key l next-window
 # bind-key h previous-window


### PR DESCRIPTION
### Motivation
- Remove the custom `prefix + s` tmux binding that opened the fuzzy session switcher so tmux's standard session key is no longer overridden.

### Description
- Deleted the `bind-key s display-popup ... '~/.local/bin/tmux-fzf-switch-session'` lines from `common/.tmux.conf` so the helper script is no longer bound to `prefix + s` (file: `common/.tmux.conf`).

### Testing
- Ran `./apply.sh --no`, `./apply.sh --no --adopt`, `./apply.sh --no --restow`, `git diff --check`, and a grep check for `bind-key s`/`tmux-fzf-switch-session`, all of which succeeded in dry-run verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01deb9aa6c832db06d859575f80d38)