### PR TITLE
Show tmux window name in status

### DIFF
--- a/common/.tmux.conf
+++ b/common/.tmux.conf
@@ -105,7 +105,7 @@ set -g status-fg        '#516e7b'
 
 set -g status-left-length  30
 set -g status-right-length 80
-set -g status-left "#[bg=#1a1b26,fg=#3C425F] #(echo '#{session_id}' | cut -c2-)  "
+set -g status-left "#[bg=#1a1b26,fg=#3C425F] #W  "
 set -g status-right "#[fg=#3C425F]#(hostname) "
 
 setw -g window-status-current-format "#[fg=#88c0d0]#[fg=#88c0d0,bg=#516e7b]#[reverse]#I #[fg=#88c0d0,bg=#1a1b26]#W#[default]#[fg=#88c0d0]"


### PR DESCRIPTION
### Motivation
- Make the top-left tmux status show the current window name instead of the session number so the active pane's purpose is clearer at a glance.

### Description
- Replace the `status-left` setting in `common/.tmux.conf` from the session-id command to `#W` so the current window name is displayed while keeping the existing status styling.
- No other tmux options were changed.

### Testing
- Ran `./apply.sh --no`, `./apply.sh --no --adopt`, and `./apply.sh --no --restow` (dry-run) and they completed successfully.
- Performed a tmux smoke test using a temporary `HOME` with a stubbed TPM script and confirmed `status-left` prints the `#W` window name, and ran `git diff --check`, all succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01dfbc15b0832d8aeab25703f6b490)