### PR TITLE
tmux: use built-in session name variable for status-left

### DIFF
--- a/common/.tmux.conf
+++ b/common/.tmux.conf
@@ -105,7 +105,7 @@ set -g status-fg        '#516e7b'
 
 set -g status-left-length  30
 set -g status-right-length 80
-set -g status-left "#[bg=#1a1b26,fg=#3C425F] #(echo '#{session_id}' | cut -c2-)  "
+set -g status-left "#[bg=#1a1b26,fg=#3C425F] #S  "
 set -g status-right "#[fg=#3C425F]#(hostname) "
 
 setw -g window-status-current-format "#[fg=#88c0d0]#[fg=#88c0d0,bg=#516e7b]#[reverse]#I #[fg=#88c0d0,bg=#1a1b26]#W#[default]#[fg=#88c0d0]"


### PR DESCRIPTION
### Motivation
- Simplify the status-left configuration by removing a subshell and text processing and use tmux's built-in session name variable for clearer, more robust output.

### Description
- Replace the previous `#(echo '#{session_id}' | cut -c2-)` subshell in `common/.tmux.conf` with the native `#S` format variable for `status-left`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01dfbc15b0832d8aeab25703f6b490)