### PR TITLE
Bind Space in tmux tree mode

### DIFF
--- a/common/.tmux.conf
+++ b/common/.tmux.conf
@@ -47,6 +47,10 @@ setw -g mode-keys vi
 # Vim style visual mode
 bind-key -T copy-mode-vi v send-keys -X begin-selection
 
+# Let Space choose the highlighted item in tmux's session/window tree (prefix s),
+# matching Enter while preserving normal Space input outside tree mode.
+bind-key -T root Space if-shell -F '#{==:#{pane_mode},tree-mode}' 'send-keys Enter' 'send-keys Space'
+
 # Bind 'C-v' to start block selection (Visual Block)
 # This chains 'begin-selection' and 'rectangle-toggle' to start block mode immediately
 bind-key -T copy-mode-vi 'C-v' send -X begin-selection \; send -X rectangle-toggle


### PR DESCRIPTION
### Motivation
- Make it possible to accept the highlighted entry in tmux's session/window tree (opened with `prefix s`) using the Space key in addition to Enter.
- Preserve normal Space behaviour for regular typing and other modes so this change only affects tree selection.

### Description
- Add a root-table binding to `common/.tmux.conf` that checks for `tree-mode` and sends `Enter` when Space is pressed, falling back to sending a normal Space otherwise.
- The new line is `bind-key -T root Space if-shell -F '#{==:#{pane_mode},tree-mode}' 'send-keys Enter' 'send-keys Space'` and is documented with a short comment in the file.

### Testing
- Ran `./apply.sh --no` as a dry-run to verify stow linking logic and it completed successfully.
- Ran `./apply.sh --no --restow` as a dry-run to verify restow behaviour and it completed successfully.
- Launched a disposable tmux server with `HOME=<tmp> tmux -L dotfiles-test -f common/.tmux.conf` and verified `list-keys -T root Space` returned the expected binding, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a023ad95d78832dae2e011a560d73de)