### PR TITLE
Enhance tmux status styling

### DIFF
--- a/common/.tmux.conf
+++ b/common/.tmux.conf
@@ -102,13 +102,22 @@ set -g allow-passthrough on
 set -g status-position top
 set -g status-bg        '#1a1b26'
 set -g status-fg        '#516e7b'
+set -g status-interval  5
 
-set -g status-left-length  30
-set -g status-right-length 80
-set -g status-left "#[bg=#1a1b26,fg=#ff9e64] #S  "
-set -g status-right "#[fg=#3C425F]#(hostname) "
+# Make pane focus and alerts easier to see without changing terminal colors.
+set -g pane-border-style        'fg=#3C425F'
+set -g pane-active-border-style 'fg=#ff9e64'
+set -g message-style            'bg=#7aa2f7,fg=#1a1b26,bold'
+set -g mode-style               'bg=#7dcfff,fg=#1a1b26,bold'
+setw -g monitor-activity on
+set -g visual-activity off
 
-setw -g window-status-current-format "#[fg=#88c0d0]#[fg=#88c0d0,bg=#516e7b]#[reverse]#I #[fg=#88c0d0,bg=#1a1b26]#W#[default]#[fg=#88c0d0]"
+set -g status-left-length  45
+set -g status-right-length 100
+set -g status-left "#[bg=#1a1b26,fg=#ff9e64] #S #[fg=#7aa2f7]#{?client_prefix,#[bg=#7aa2f7,fg=#1a1b26,bold] PREFIX #[bg=#1a1b26,fg=#7aa2f7] ,}"
+set -g status-right "#[fg=#3C425F]#(hostname) #[fg=#565f89]• #[fg=#9ece6a]%a %b %d #[fg=#7dcfff]%H:%M "
+
+setw -g window-status-current-format "#[fg=#88c0d0]#[fg=#88c0d0,bg=#516e7b]#[reverse]#I #[fg=#88c0d0,bg=#1a1b26]#W#{?window_flags, #[fg=#ff9e64]#F,}#[default]#[fg=#88c0d0]"
 # set -g status-justify centre
 
 # Improve automatic window naming so panes running a shell show the
@@ -117,9 +126,8 @@ set-option -g allow-rename off
 set-window-option -g automatic-rename on
 set-window-option -g automatic-rename-format '#(~/.local/bin/tmux-status-name.sh "#{pane_current_path}" "#{pane_current_command}")'
 
-# Remove flags for inactive windows
-set-option -g window-status-format " #[fg=#3C425F]#I #[fg=#88c0d0]#W "
-# Remove flags for the current (active) window
+# Keep inactive windows quiet, but surface activity/bell flags when they matter.
+set-option -g window-status-format " #[fg=#3C425F]#I #[fg=#88c0d0]#W#{?window_flags, #[fg=#ff9e64]#F,} "
 # set-option -g window-status-current-format "#I:#W"
 
 # Tmux Plugin Manager (TPM) and plugins


### PR DESCRIPTION
### Motivation
- Improve visual clarity and feedback in tmux by surfacing prefix state, activity/bell flags, and a compact date/time segment while keeping the existing color scheme.
- Make pane focus, messages, and copy/mode indications more visible without changing terminal colors.

### Description
- Updated `common/.tmux.conf` to add `status-interval`, increase `status-left-length`/`status-right-length`, and include a visible `PREFIX` badge plus date/time in `status-left`/`status-right`.
- Added pane and UI styling via `pane-border-style`, `pane-active-border-style`, `message-style`, and `mode-style`, and enabled `monitor-activity` while disabling `visual-activity`.
- Enhanced `window-status-current-format` and `window-status-format` to show activity/bell flags for windows.
- No other files were changed; the affected package is `common` (`common/.tmux.conf`).

### Testing
- Ran `./apply.sh --no` (dry-run) which completed successfully.
- Ran `./apply.sh --no --restow` (dry-run restow) which completed successfully.
- Launched a temporary tmux server with `HOME=$(mktemp -d) tmux -f common/.tmux.conf -L dotfiles-test-$$ new-session -d 'sleep 2'` and validated the rendered `status-left`/`status-right` via `tmux display-message -p`, which returned the expected formatted string.
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a025f8e29dc832dbee605b172ae8a51)