### PR TITLE
Add tmux popup helpers and cheatsheet

### DIFF
--- a/common/.local/bin/tmux-cheatsheet
+++ b/common/.local/bin/tmux-cheatsheet
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+set -eu
+
+cat <<'HELP'
+ tmux quick sheet
+ ────────────────
+ prefix r        reload ~/.tmux.conf
+ prefix h/j/k/l  move between panes
+ prefix C        new window in the current path
+ prefix </>      move window left/right
+ prefix t        open a floating shell in the current path
+ prefix g        open lazygit in a floating popup
+ prefix s        fuzzy-switch sessions with fzf
+
+ copy mode
+ prefix [        enter copy mode
+ v               begin selection
+ C-v             block selection
+ y               copy and leave copy mode
+ S-F4/S-F6       scroll 16 lines up/down
+
+ local tweaks can live in ~/.tmux.conf.local
+HELP
+
+printf '\nPress Enter to close… '
+# Use /dev/tty so the prompt works even if stdin is redirected.
+IFS= read -r _ </dev/tty || true

--- a/common/.tmux.conf
+++ b/common/.tmux.conf
@@ -1,6 +1,6 @@
 # Easy source of config
 unbind-key r
-bind-key   r  source-file ~/.tmux.conf
+bind-key   r  source-file ~/.tmux.conf \; display-message 'tmux config reloaded'
 
 # Primary prefix (default)
 set -g prefix M-a
@@ -79,6 +79,12 @@ bind-key -r '<' run-shell 'id=$(tmux display -p "#{window_id}"); tmux swap-windo
 bind-key -r '>' run-shell 'id=$(tmux display -p "#{window_id}"); tmux swap-window -t:+1; tmux select-window -t "$id"'
 bind-key C new-window -a -c "#{pane_current_path}"
 
+# Nice popups for quick tasks without disturbing the pane layout
+bind-key ? display-popup -E -w 72 -h 24 '~/.local/bin/tmux-cheatsheet'
+bind-key t display-popup -E -w 80% -h 80% -d "#{pane_current_path}" "${SHELL:-/bin/sh}"
+bind-key g display-popup -E -w 90% -h 90% -d "#{pane_current_path}" 'if command -v lazygit >/dev/null 2>&1; then lazygit; else git status; printf \"\nPress Enter to close… \"; read _; fi'
+bind-key s display-popup -E -w 80% -h 80% '~/.local/bin/tmux-fzf-switch-session'
+
 # after your prefix declaration
 # bind-key l next-window
 # bind-key h previous-window
@@ -105,8 +111,8 @@ set -g status-fg        '#516e7b'
 
 set -g status-left-length  30
 set -g status-right-length 80
-set -g status-left "#[bg=#1a1b26,fg=#ff9e64] #S  "
-set -g status-right "#[fg=#3C425F]#(hostname) "
+set -g status-left "#{?client_prefix,#[bg=#ff9e64,fg=#1a1b26,bold] PREFIX #[default] ,}#[bg=#1a1b26,fg=#ff9e64] #S  "
+set -g status-right "#[fg=#3C425F]#(hostname) #[fg=#516e7b]%H:%M "
 
 setw -g window-status-current-format "#[fg=#88c0d0]#[fg=#88c0d0,bg=#516e7b]#[reverse]#I #[fg=#88c0d0,bg=#1a1b26]#W#[default]#[fg=#88c0d0]"
 # set -g status-justify centre


### PR DESCRIPTION
### Motivation
- Improve tmux ergonomics by adding quick, non-disruptive popups for common tasks and a handy reference so users can access tools without disturbing pane layouts.
- Provide clearer feedback when reloading the tmux config and show an explicit prefix indicator plus a clock in the status bar for better situational awareness.

### Description
- Added popup bindings to `common/.tmux.conf` for a cheat sheet (`prefix ?`), a floating shell (`prefix t`), lazygit/git-status popup (`prefix g`), and fzf session switching in a popup (`prefix s`).
- Made `prefix r` reload the config and display a small confirmation message, and updated the status-left/right to show a visible `PREFIX` indicator and the current time.
- Added a new executable helper `common/.local/bin/tmux-cheatsheet` which prints a short quick-sheet and waits for Enter before closing, designed to be shown via `display-popup`.
- Changes live in the `common` package (tmux config and local bin helper) so they will be symlinked by the dotfiles stow workflow.

### Testing
- Ran `git diff --check` with no issues detected, and `shellcheck common/.local/bin/tmux-cheatsheet` which returned clean results.
- Validated shell syntax with `sh -n common/.local/bin/tmux-cheatsheet` and executed a headless tmux sanity test by starting a session with `HOME="$PWD/common" tmux -L dotfiles-test -f common/.tmux.conf new-session -d -s dotfiles-test 'sleep 5'` and then killing the test server; the run succeeded.
- Performed the repo-required stow previews using `./apply.sh --no`, `./apply.sh --no --adopt`, and `./apply.sh --no --restow` in dry-run mode and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a025f8e29dc832dbee605b172ae8a51)