### PR TITLE
Increase terminal scrollback limits to 1,000,000 lines

### DIFF
--- a/common/.config/Code/User/settings.json
+++ b/common/.config/Code/User/settings.json
@@ -33,7 +33,7 @@
   // Prompt when opening files from untrusted workspaces
   "security.workspace.trust.untrustedFiles": "open",
   // Increase terminal scrollback similar to using a terminal split in Neovim
-  "terminal.integrated.scrollback": 10000,
+  "terminal.integrated.scrollback": 1000000,
 
   // Unified Size
   "editor.lineHeight": 1.44,

--- a/common/.config/kitty/kitty.conf
+++ b/common/.config/kitty/kitty.conf
@@ -18,7 +18,7 @@ bold_italic_font JetBrainsMono Nerd Font Bold Italic
 disable_ligatures never
 
 # Quality of life improvements
-scrollback_lines 100000
+scrollback_lines 1000000
 enable_audio_bell no
 confirm_os_window_close 0
 macos_option_as_alt yes

--- a/common/.config/wezterm/wezterm.lua
+++ b/common/.config/wezterm/wezterm.lua
@@ -71,6 +71,6 @@ config.default_cursor_style = 'SteadyBlock'
 
 -- QoL
 config.audible_bell = 'Disabled'
-config.scrollback_lines = 100000
+config.scrollback_lines = 1000000
 
 return config

--- a/common/.tmux.conf
+++ b/common/.tmux.conf
@@ -20,7 +20,7 @@ setw -g pane-base-index 1
 set -g renumber-windows on
 
 # Increase scrollback history
-set -g history-limit 100000
+set -g history-limit 1000000
 
 # Enable mouse support for pane selection, resizing, and scrolling
 set -g mouse on
@@ -132,7 +132,7 @@ set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @continuum-restore 'off'
 set -g @continuum-save-interval '15'
 set -g @resurrect-capture-pane-contents 'on'
-set -g @resurrect-max-pane-history-lines '100000'
+set -g @resurrect-max-pane-history-lines '1000000'
 # Restore additional tools that tmux-resurrect does not handle by default
 set -g @resurrect-processes 'lazygit'
 


### PR DESCRIPTION
### Motivation
- Allow much deeper terminal history so users can scroll back up to 1,000,000 lines across shells and editors.
- Keep scrollback behavior consistent across GUI terminals, multiplexer, and editor-integrated terminals.

### Description
- Increased Kitty scrollback by changing `scrollback_lines` to `1000000` in `common/.config/kitty/kitty.conf`.
- Increased WezTerm scrollback by setting `config.scrollback_lines = 1000000` in `common/.config/wezterm/wezterm.lua`.
- Increased tmux history and tmux-resurrect capture by setting `set -g history-limit 1000000` and `set -g @resurrect-max-pane-history-lines '1000000'` in `common/.tmux.conf`.
- Increased VS Code integrated terminal scrollback by setting `"terminal.integrated.scrollback": 1000000` in `common/.config/Code/User/settings.json`.

### Testing
- Ran `./apply.sh --no` as a dry-run which completed successfully with no filesystem changes reported.
- Ran `./apply.sh --no --restow` to preview restow behavior which completed successfully in simulation mode.
- Ran `git diff --check` and `./apply.sh` checks; no issues were reported by automated checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0262aa1b10832da176265e07ca2046)