### PR TITLE
Add tmux session tree binding

### DIFF
--- a/common/.tmux.conf
+++ b/common/.tmux.conf
@@ -78,7 +78,7 @@ bind-key -T copy-mode S-F6 send-keys -X -N 16 scroll-down
 bind-key -r '<' run-shell 'id=$(tmux display -p "#{window_id}"); tmux swap-window -t:-1; tmux select-window -t "$id"'
 bind-key -r '>' run-shell 'id=$(tmux display -p "#{window_id}"); tmux swap-window -t:+1; tmux select-window -t "$id"'
 bind-key C new-window -a -c "#{pane_current_path}"
-bind-key s choose-tree -sZ -O time -r
+bind-key s choose-tree -sZ -O time
 
 # after your prefix declaration
 # bind-key l next-window

--- a/common/.tmux.conf
+++ b/common/.tmux.conf
@@ -78,6 +78,7 @@ bind-key -T copy-mode S-F6 send-keys -X -N 16 scroll-down
 bind-key -r '<' run-shell 'id=$(tmux display -p "#{window_id}"); tmux swap-window -t:-1; tmux select-window -t "$id"'
 bind-key -r '>' run-shell 'id=$(tmux display -p "#{window_id}"); tmux swap-window -t:+1; tmux select-window -t "$id"'
 bind-key C new-window -a -c "#{pane_current_path}"
+bind-key s choose-tree -sZ -O time -r
 
 # after your prefix declaration
 # bind-key l next-window


### PR DESCRIPTION
### Motivation
- Provide a convenient `prefix + s` binding to quickly open the tmux session tree in session mode, zoomed and sorted by recent time.

### Description
- Add `bind-key s choose-tree -sZ -O time -r` to `common/.tmux.conf` to open the session tree with the requested options (file: `common/.tmux.conf`).

### Testing
- Ran `./apply.sh --no` and `./apply.sh --no --restow` (dry-run) which completed successfully; a runtime `tmux` server start/check could not be executed because `tmux` is not installed in the test environment so that check was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05170ae7f0832d81cdfa539cb39574)