### PR TITLE
Add Yazi keybinding to copy local rsync pull command to clipboard

### DIFF
--- a/common/.config/yazi/keymap.toml
+++ b/common/.config/yazi/keymap.toml
@@ -93,6 +93,11 @@ run = "copy name_without_ext"
 desc = "Copy the filename without extension"
 
 [[mgr.prepend_keymap]]
+on = [ "y", "D" ]
+run = "shell 'yazi-copy-download-command \"$@\"'"
+desc = "Copy local rsync download command"
+
+[[mgr.prepend_keymap]]
 on = ["s"]
 run = "search --via=rg"
 desc = "Search files by content via ripgrep"

--- a/common/.local/bin/yazi-copy-download-command
+++ b/common/.local/bin/yazi-copy-download-command
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  printf 'yazi-copy-download-command: no file or directory selected\n' >&2
+  exit 1
+fi
+
+if [[ -z "${SSH_CONNECTION:-}" ]]; then
+  printf 'yazi-copy-download-command: not running over SSH\n' >&2
+  exit 1
+fi
+
+remote_host="${SSH_CONNECTION##* }"
+remote_user="${USER:-$(id -un)}"
+
+escape_single_quotes() {
+  printf "%s" "$1" | sed "s/'/'\\\\''/g"
+}
+
+build_remote_arg() {
+  local path=$1
+  local escaped
+  escaped="$(escape_single_quotes "$path")"
+  printf "'%s@%s:%s'" "$remote_user" "$remote_host" "$escaped"
+}
+
+cmd="rsync -avz --progress"
+for path in "$@"; do
+  cmd+=" $(build_remote_arg "$path")"
+done
+cmd+=" ~/Downloads/"
+
+printf '%s\n' "$cmd" | osc-copy
+printf 'Copied local download command to clipboard:\n%s\n' "$cmd"


### PR DESCRIPTION
### Motivation
- Provide an easy way to download a file or directory highlighted in Yazi on a remote host to the local Mac by generating a ready-to-run `rsync` pull command instead of executing transfers from the remote.
- Keep the change simple and safe by copying the command to the local clipboard (via existing `osc-copy`/OSC52) so the user can paste and run it in their local terminal.
- Integrate the helper as a local helper script and expose it with a concise Yazi keybinding to match the existing keymap style.

### Description
- Added a helper script `common/.local/bin/yazi-copy-download-command` that validates SSH context, constructs a quoted `rsync -avz --progress` command for the selected paths, and pipes it to `osc-copy` to copy via OSC52; the script is executable and shell-safe for paths containing single quotes.
- Added a Yazi keybinding entry in `common/.config/yazi/keymap.toml` for `y` then `D` that runs `shell 'yazi-copy-download-command "$@"'` on the current selection.
- The change does not execute transfers on the remote host; it copies a local pull command like `rsync -avz --progress 'user@host:/path' ~/Downloads/` for the local user to run.

### Testing
- Ran a shell syntax check with `bash -n common/.local/bin/yazi-copy-download-command`, which succeeded.
- Attempted repository stow preview checks with `./apply.sh --no`, `./apply.sh --no --adopt`, and `./apply.sh --no --restow`, each of which produced dry-run output but ultimately failed in this environment due to `stow: command not found`.
- All automated checks available in this environment passed where applicable and no additional automated tests were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10f1fcc00c832daa16ebfd6daed2a8)