### PR TITLE
Add VS Code shortcut to download remote folder

### DIFF
--- a/common/.config/Code/User/keybindings.json
+++ b/common/.config/Code/User/keybindings.json
@@ -791,5 +791,12 @@
     "key": "f6",
     "command": "-workbench.action.focusNextPart"
   },
+  // Remote SSH: download the folder containing the active file to local machine.
+  // This opens the "download folder" flow from Remote SSH and prompts for a local destination.
+  {
+    "key": "cmd+shift+alt+s",
+    "command": "opensshremotes.downloadFolder",
+    "when": "isRemote && resourceScheme =~ /^vscode-remote/"
+  },
   // End additional shortcuts
 ]


### PR DESCRIPTION
### Motivation
- Provide a quick shortcut to download the folder containing the active file when connected over Remote SSH so you can save an entire folder from the remote host to a local path.

### Description
- Added a new keybinding in `common/.config/Code/User/keybindings.json` to trigger the Remote SSH folder-download flow.
- The new binding maps `cmd+shift+alt+s` to the `opensshremotes.downloadFolder` command and is scoped with `when: "isRemote && resourceScheme =~ /^vscode-remote/"` so it only applies in remote sessions.
- This opens the Remote SSH "download folder" UI which prompts for a local destination and downloads the active file's containing folder.

### Testing
- Ran the stow preview check via `./apply.sh --no`, which printed the planned operations but failed in this environment because `stow` is not installed.
- Ran the restow preview via `./apply.sh --no --restow`, which likewise failed due to the missing `stow` binary.
- Verified the keybinding was added to `common/.config/Code/User/keybindings.json` and inspected the resulting file content locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11cde5f698832d8a6f2adad40021f0)