### PR TITLE
Add yazi shortcut and script to copy rsync -avz command for current directory

### DIFF
--- a/common/.config/yazi/keymap.toml
+++ b/common/.config/yazi/keymap.toml
@@ -93,6 +93,11 @@ run = "copy name_without_ext"
 desc = "Copy the filename without extension"
 
 [[mgr.prepend_keymap]]
+on = [ "f", "r" ]
+run = "shell 'copy-rsync-command \"$PWD\"'"
+desc = "Copy rsync command for current directory"
+
+[[mgr.prepend_keymap]]
 on = ["s"]
 run = "search --via=rg"
 desc = "Search files by content via ripgrep"

--- a/common/.local/bin/copy-rsync-command
+++ b/common/.local/bin/copy-rsync-command
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+src_dir="${1:-$PWD}"
+dest_base="${2:-$HOME/Downloads}"
+
+src_dir="${src_dir%/}"
+if [[ ! -d "$src_dir" ]]; then
+  echo "Directory does not exist: $src_dir" >&2
+  exit 1
+fi
+
+remote_host="${SSH_RSYNC_HOST:-$(hostname -s)}"
+timestamp="$(date +%Y%m%d-%H%M%S)"
+dir_name="$(basename "$src_dir")"
+dest_dir="${dest_base%/}/${dir_name}-${timestamp}"
+
+printf -v rsync_cmd 'rsync -avz %q:%q/ %q/' "$remote_host" "$src_dir" "$dest_dir"
+printf '%s\n' "$rsync_cmd" | osc-copy
+printf '%s\n' "$rsync_cmd"


### PR DESCRIPTION
### Motivation
- Provide a quick way from Yazi to copy a ready-to-run `rsync -avz` pull command for the current folder so the remote/controller can run it without crafting paths manually.
- Keep the feature as a standalone utility so it can be invoked outside Yazi and reused by other tooling.

### Description
- Add a new executable script `common/.local/bin/copy-rsync-command` that accepts an optional source directory (defaults to `PWD`) and optional destination base (defaults to `~/Downloads`), builds an `rsync -avz` command that pulls the source into `~/Downloads/<dir>-<timestamp>/`, and prints the command to stdout while copying it to the terminal clipboard via `osc-copy` (uses `SSH_RSYNC_HOST` when set, otherwise `hostname -s`).
- Add a Yazi keybinding `f r` in `common/.config/yazi/keymap.toml` to run `shell 'copy-rsync-command "$PWD"'` so pressing `f r` in Yazi copies the rsync command for the current directory.
- Ensure the generated destination directory is suffixed with a timestamp in `YYYYMMDD-HHMMSS` format to avoid collisions and preserve snapshots.

### Testing
- Ran `./apply.sh --no`, `./apply.sh --no --adopt`, and `./apply.sh --no --restow` as the required dry-run checks but they could not complete because `stow` is not installed in the environment (dry-run output shows `stow: command not found`).
- Attempted `shellcheck common/.local/bin/copy-rsync-command` but the environment lacks `shellcheck` so static shell linting could not be performed (`shellcheck: command not found`).
- Performed local commit of the changes and updated the Yazi keymap file; those file changes are staged and committed in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13b4d3faf8832dac421fb4062d863c)