### PR TITLE
Rename Yazi download-copy helper command

### DIFF
--- a/common/.config/yazi/keymap.toml
+++ b/common/.config/yazi/keymap.toml
@@ -94,7 +94,7 @@ desc = "Copy the filename without extension"
 
 [[mgr.prepend_keymap]]
 on = [ "f", "d" ]
-run = "shell 'if [ -d \"$1\" ]; then copy-rsync-command \"$1\"; else copy-rsync-command; fi'"
+run = "shell 'if [ -d \"$1\" ]; then copy-download-command \"$1\"; else copy-download-command; fi'"
 desc = "Copy download command for current or hovered directory"
 
 [[mgr.prepend_keymap]]


### PR DESCRIPTION
### Motivation
- Align the Yazi keybinding with the renamed helper utility so the `f d` mapping invokes the correct download-copy helper.

### Description
- Replaced `copy-rsync-command` with `copy-download-command` in `common/.config/yazi/keymap.toml` for the `on = [ "f", "d" ]` mapping so the binding now runs the new helper.

### Testing
- Ran `./apply.sh --no` and `./apply.sh --no --restow` as dry-run previews, and both executed until the script attempted to run `stow` and stopped with `stow: command not found`, so the restow/apply checks could not fully complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13c46cf544832dbc16597faeea084e)